### PR TITLE
Use hero-matching gradient for non-home header instead of white

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -152,8 +152,13 @@
 }
 
 .header--light {
-  border-bottom-color: rgba($color-dark, 0.08);
-  background-color: rgba($color-white, 0.98);
+  border-bottom-color: rgba($color-white, 0.12);
+  background: linear-gradient(
+    135deg,
+    $color-dark 0%,
+    $color-primary 55%,
+    $color-dark 100%
+  );
 }
 
 .header__inner {
@@ -215,7 +220,8 @@
   margin: 0 auto;
 }
 
-.header--on-hero .header__toggle-bar {
+.header--on-hero .header__toggle-bar,
+.header--light .header__toggle-bar {
   background-color: $color-white;
 }
 
@@ -253,17 +259,26 @@
 }
 
 .header--on-hero .header__logo,
-.header--on-hero .header__nav-link {
+.header--on-hero .header__nav-link,
+.header--light .header__logo,
+.header--light .header__nav-link {
   color: $color-white;
   text-shadow: 0 4px 10px rgba($color-dark, 0.5);
 }
 
-.header--on-hero .header__nav-link:hover {
+.header--on-hero .header__logo:hover,
+.header--light .header__logo:hover {
+  color: $color-white;
+}
+
+.header--on-hero .header__nav-link:hover,
+.header--light .header__nav-link:hover {
   color: $color-white;
   background-color: rgba($color-white, 0.12);
 }
 
-.header--on-hero .header__nav-link--active {
+.header--on-hero .header__nav-link--active,
+.header--light .header__nav-link--active {
   color: $color-white;
   background-color: rgba($color-white, 0.22);
 }

--- a/src/styles/_responsive.scss
+++ b/src/styles/_responsive.scss
@@ -37,7 +37,8 @@
     transition: max-height $transition-base, opacity $transition-fast, padding $transition-fast;
   }
 
-  .header--on-hero .header__nav {
+  .header--on-hero .header__nav,
+  .header--light .header__nav {
     background-color: rgba($color-dark, 0.95);
     border-bottom-color: rgba($color-white, 0.1);
   }


### PR DESCRIPTION
Replaces the white .header--light background with a 135deg dark-teal
gradient using the hero's colors, and flips the logo, nav links and
mobile menu to white text for legibility.