### PR TITLE
Use hero-matching gradient for site header instead of white

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -133,24 +133,7 @@
   backdrop-filter: blur(14px);
 }
 
-.header--on-hero {
-  border-bottom-color: rgba($color-white, 0.12);
-  position: relative;
-}
-
-.header--on-hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba($color-dark, 0.75) 0%,
-    rgba($color-dark, 0.25) 60%,
-    rgba($color-dark, 0) 100%
-  );
-  z-index: 0;
-}
-
+.header--on-hero,
 .header--light {
   border-bottom-color: rgba($color-white, 0.12);
   background: linear-gradient(


### PR DESCRIPTION
## Summary
Replaces the white site header with a gradient that matches the hero, on every page.

- **Inner pages** (`.header--light`): swapped the near-white `rgba(white, 0.98)` background for a `135deg` dark-teal gradient using the hero's colors (`$color-dark → $color-primary → $color-dark`).
- **Home page** (`.header--on-hero`): previously a transparent bar with a dark→transparent `::before` fade, which showed through as white once scrolled past the hero / over the light page background. Now uses the same solid hero gradient, so it's consistent and never white.
- Flipped the logo, nav links, hover/active states, hamburger bars, and the mobile dropdown panel to white text/dark background for legibility on the new gradient.

## Files
- `src/styles/_layout.scss` — header background gradient + white text rules
- `src/styles/_responsive.scss` — dark mobile dropdown for the non-home header

## Testing
- `npm run build` passes (16 pages built).

https://claude.ai/code/session_01Kb9dhriy3JXRFRct3ZezFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb9dhriy3JXRFRct3ZezFE)_