### PR TITLE
Logo: single italic wordmark with gradient initial "e"

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -71,7 +71,7 @@ const currentYear = new Date().getFullYear();
   {/* Google Fonts: Space Grotesk (títulos) + Inter (texto) + JetBrains Mono (código) */}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700;800&family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,300..600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700;800&family=Fraunces:ital,opsz,wght@1,9..144,300..600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   {/* Feed */}
   <link rel="alternate" type="application/atom+xml" title={`${SITE_TITLE} Feed`} href={url('/atom.xml')}>
@@ -90,19 +90,8 @@ const currentYear = new Date().getFullYear();
     <!-- ================================================================ -->
     <header class={`header${isHome ? ' header--on-hero' : ' header--light'}`}>
       <div class="container header__inner">
-        <a href={url('/')} class="header__logo">
-          <span class="header__logo-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <defs>
-                <linearGradient id="logo-e-gradient" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0%" stop-color="#5EEAD4"/>
-                  <stop offset="100%" stop-color="#FBBF24"/>
-                </linearGradient>
-              </defs>
-              <text x="14" y="20" text-anchor="middle" font-family="Fraunces, Georgia, 'Times New Roman', serif" font-style="italic" font-weight="300" font-size="32" style="font-variation-settings: 'opsz' 144;" fill="url(#logo-e-gradient)">e</text>
-            </svg>
-          </span>
-          Eraldia
+        <a href={url('/')} class="header__logo" aria-label="Eraldia">
+          <span class="logo-e" aria-hidden="true">e</span>raldia
         </a>
 
         <input type="checkbox" id="nav-toggle" class="header__nav-toggle" aria-hidden="true">
@@ -136,7 +125,7 @@ const currentYear = new Date().getFullYear();
       <div class="container footer__inner">
         <div class="footer__top">
           <div class="footer__brand">
-            <div class="footer__logo">Eraldia</div>
+            <div class="footer__logo"><span class="logo-e" aria-hidden="true">e</span>raldia</div>
             <p class="footer__tagline">{TAGLINE}</p>
           </div>
 

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -156,11 +156,12 @@
 .header__logo {
   display: flex;
   align-items: center;
-  gap: $space-2;
   font-family: $font-logo;
-  font-optical-sizing: auto;
-  font-size: 1.4rem;
-  font-weight: 600;
+  font-style: italic;
+  font-variation-settings: 'opsz' 144;
+  text-transform: lowercase;
+  font-size: 1.65rem;
+  font-weight: 500;
   color: $color-dark;
   text-decoration: none;
   letter-spacing: 0;
@@ -171,12 +172,14 @@
   }
 }
 
-.header__logo-icon {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+// Gradient initial "e" — doubles as the brand mark within the wordmark
+.logo-e {
+  background: linear-gradient(135deg, #5EEAD4 0%, #FBBF24 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  text-shadow: none;
 }
 
 // Hamburger toggle (CSS-only, hidden on desktop)
@@ -301,8 +304,12 @@
 }
 
 .footer__logo {
-  font-size: $font-size-xl;
-  font-weight: $font-weight-bold;
+  font-family: $font-logo;
+  font-style: italic;
+  font-variation-settings: 'opsz' 144;
+  text-transform: lowercase;
+  font-size: 1.65rem;
+  font-weight: 500;
   color: $color-white;
   margin-bottom: $space-3;
 }


### PR DESCRIPTION
## Summary
Refines the logo into a single, cohesive wordmark.

- Drops the separate "e" icon that sat next to the wordmark — it duplicated the word's own leading "e".
- The logo is now lowercase **"eraldia"** in **Fraunces italic, weight 500**, with the leading **"e" carrying the teal→amber gradient** (`#5EEAD4 → #FBBF24`) so it doubles as the brand mark.
- Applied to **both the header and footer** logos (via a shared `.logo-e` gradient-text class using `background-clip: text`).
- The **favicon** keeps the standalone gradient "e" as the icon-only mark.

## Files
- `src/layouts/BaseLayout.astro` — header + footer markup (gradient first-letter span, icon removed)
- `src/styles/_layout.scss` — `.logo-e` gradient text + logo typography (weight 500), removed unused `.header__logo-icon`

## Testing
- `npm run build` passes (16 pages built).

https://claude.ai/code/session_01Kb9dhriy3JXRFRct3ZezFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb9dhriy3JXRFRct3ZezFE)_