### PR TITLE
Typography: mix Fraunces italic with modern fonts as editorial accent

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -304,6 +304,10 @@
 }
 
 .hero__subtitle {
+  font-family: $font-accent;
+  font-style: italic;
+  font-variation-settings: 'opsz' 72;
+  font-weight: $font-weight-normal;
   font-size: clamp(1.125rem, 2.4vw, 1.5rem);
   color: rgba($color-white, 0.85);
   line-height: $line-height-base;
@@ -640,6 +644,10 @@
 }
 
 .cta__desc {
+  font-family: $font-accent;
+  font-style: italic;
+  font-variation-settings: 'opsz' 36;
+  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: rgba($color-white, 0.85);
   margin-bottom: $space-6;
@@ -776,6 +784,10 @@
 }
 
 .page-header__desc {
+  font-family: $font-accent;
+  font-style: italic;
+  font-variation-settings: 'opsz' 36;
+  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: $color-text-light;
   max-width: 600px;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -412,6 +412,10 @@
 }
 
 .section__subtitle {
+  font-family: $font-accent;
+  font-style: italic;
+  font-variation-settings: 'opsz' 36;
+  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: $color-text-light;
   line-height: $line-height-base;

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -56,6 +56,9 @@ p {
 }
 
 .lead {
+  font-family: $font-accent;
+  font-style: italic;
+  font-variation-settings: 'opsz' 72;
   font-size: $font-size-xl;
   line-height: 1.5;
   color: $color-text-light;
@@ -138,9 +141,12 @@ blockquote {
   border-radius: 0 $border-radius $border-radius 0;
 
   p {
+    font-family: $font-accent;
     font-size: $font-size-lg;
     color: $color-text-light;
     font-style: italic;
+    font-variation-settings: 'opsz' 36;
+    font-weight: $font-weight-normal;
     margin-bottom: 0;
 
     &:last-child {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -31,6 +31,7 @@ $color-bg-alt:         #EFF4F1;
 $font-heading: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 $font-body:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 $font-logo:    'Fraunces', Georgia, 'Times New Roman', serif;
+$font-accent:  'Fraunces', Georgia, 'Times New Roman', serif;
 $font-code:    'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
 
 $font-size-base:  1rem;       // 16px


### PR DESCRIPTION
Apply the brand's Fraunces italic (already used in the logo) to supporting
text elements — hero subtitle, section subtitles, lead paragraphs, blockquotes,
CTA descriptions, and page-header descriptions. Headings remain in Space Grotesk
and body text in Inter, creating a deliberate editorial rhythm: bold geometric
title → elegant serif italic description.

https://claude.ai/code/session_015viy75qm2T9z29gxqSec7X