### PR TITLE
Typography: Fraunces italic for headings, Inter for body

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -304,10 +304,6 @@
 }
 
 .hero__subtitle {
-  font-family: $font-accent;
-  font-style: italic;
-  font-variation-settings: 'opsz' 72;
-  font-weight: $font-weight-normal;
   font-size: clamp(1.125rem, 2.4vw, 1.5rem);
   color: rgba($color-white, 0.85);
   line-height: $line-height-base;
@@ -644,10 +640,6 @@
 }
 
 .cta__desc {
-  font-family: $font-accent;
-  font-style: italic;
-  font-variation-settings: 'opsz' 36;
-  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: rgba($color-white, 0.85);
   margin-bottom: $space-6;
@@ -784,10 +776,6 @@
 }
 
 .page-header__desc {
-  font-family: $font-accent;
-  font-style: italic;
-  font-variation-settings: 'opsz' 36;
-  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: $color-text-light;
   max-width: 600px;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -412,10 +412,6 @@
 }
 
 .section__subtitle {
-  font-family: $font-accent;
-  font-style: italic;
-  font-variation-settings: 'opsz' 36;
-  font-weight: $font-weight-normal;
   font-size: $font-size-lg;
   color: $color-text-light;
   line-height: $line-height-base;

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -7,6 +7,8 @@
 // --------------------------------------------------------------------------
 h1, h2, h3, h4, h5, h6 {
   font-family: $font-heading;
+  font-style: italic;
+  font-variation-settings: 'opsz' 72;
   font-weight: $font-weight-bold;
   line-height: $line-height-heading;
   color: $color-dark;
@@ -15,33 +17,39 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   font-size: clamp(2rem, 5vw, 3.25rem);
-  font-weight: $font-weight-extrabold;
+  font-weight: $font-weight-semibold;
+  font-variation-settings: 'opsz' 144;
   letter-spacing: -0.03em;
 }
 
 h2 {
   font-size: clamp(1.625rem, 3.5vw, 2.5rem);
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
+  font-variation-settings: 'opsz' 72;
 }
 
 h3 {
   font-size: clamp(1.25rem, 2.5vw, 1.75rem);
   font-weight: $font-weight-semibold;
+  font-variation-settings: 'opsz' 48;
 }
 
 h4 {
   font-size: clamp(1.125rem, 2vw, 1.375rem);
-  font-weight: $font-weight-semibold;
+  font-weight: $font-weight-medium;
+  font-variation-settings: 'opsz' 36;
 }
 
 h5 {
   font-size: $font-size-lg;
   font-weight: $font-weight-medium;
+  font-variation-settings: 'opsz' 24;
 }
 
 h6 {
   font-size: $font-size-base;
   font-weight: $font-weight-medium;
+  font-variation-settings: 'opsz' 18;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -56,9 +64,6 @@ p {
 }
 
 .lead {
-  font-family: $font-accent;
-  font-style: italic;
-  font-variation-settings: 'opsz' 72;
   font-size: $font-size-xl;
   line-height: 1.5;
   color: $color-text-light;
@@ -141,12 +146,9 @@ blockquote {
   border-radius: 0 $border-radius $border-radius 0;
 
   p {
-    font-family: $font-accent;
     font-size: $font-size-lg;
     color: $color-text-light;
     font-style: italic;
-    font-variation-settings: 'opsz' 36;
-    font-weight: $font-weight-normal;
     margin-bottom: 0;
 
     &:last-child {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -28,10 +28,9 @@ $color-bg-alt:         #EFF4F1;
 // --------------------------------------------------------------------------
 // Typography
 // --------------------------------------------------------------------------
-$font-heading: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+$font-heading: 'Fraunces', Georgia, 'Times New Roman', serif;
 $font-body:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 $font-logo:    'Fraunces', Georgia, 'Times New Roman', serif;
-$font-accent:  'Fraunces', Georgia, 'Times New Roman', serif;
 $font-code:    'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
 
 $font-size-base:  1rem;       // 16px


### PR DESCRIPTION
## Summary

- Switches all headings (`h1`–`h6`) and every component title class to **Fraunces italic**, matching the brand's logo wordmark
- Body text, supporting copy, buttons, and smaller text remain in **Inter**
- Each heading level gets a calibrated `opsz` axis value (144 → h1, down to 18 → h6) to get the right optical weight at each size — h1 gets the same thin, high-contrast treatment as the logo

## Test plan

- [ ] Check hero section — `h1.hero__title` should render in Fraunces italic
- [ ] Check section headings throughout the homepage — `h2.section__title`, `h3.card__title` etc. should all be Fraunces italic
- [ ] Check body paragraphs, lead text, and buttons remain in Inter (no Fraunces bleed into body text)
- [ ] Check the logo wordmark still renders correctly (unchanged)
- [ ] Check at mobile breakpoints — heading sizes use `clamp()`, verify Fraunces italic reads well at small sizes

https://claude.ai/code/session_015viy75qm2T9z29gxqSec7X

---
_Generated by [Claude Code](https://claude.ai/code/session_015viy75qm2T9z29gxqSec7X)_