### PR TITLE
Footer: add brand icon above wordmark

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -125,6 +125,7 @@ const currentYear = new Date().getFullYear();
       <div class="container footer__inner">
         <div class="footer__top">
           <div class="footer__brand">
+            <img src={url('/images/favicon.svg')} alt="Eraldia" class="footer__icon" width="48" height="48">
             <div class="footer__logo"><span class="logo-e" aria-hidden="true">e</span>raldia</div>
             <p class="footer__tagline">{TAGLINE}</p>
           </div>

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -303,6 +303,14 @@
   max-width: 360px;
 }
 
+.footer__icon {
+  display: block;
+  width: 48px;
+  height: 48px;
+  border-radius: $border-radius-lg;
+  margin-bottom: $space-4;
+}
+
 .footer__logo {
   font-family: $font-logo;
   font-style: italic;


### PR DESCRIPTION
## Summary

- Adds the `favicon.svg` brand icon (the gradient italic "e") above the "eraldia" wordmark in the footer brand section
- Icon renders at 48×48px with rounded corners, consistent with the site's border-radius system
- Sits neatly above the existing wordmark and tagline in `.footer__brand`

## Test plan

- [ ] Footer shows the gradient "e" icon above the wordmark on desktop
- [ ] Footer renders correctly on mobile — icon should not overflow or misalign
- [ ] Icon loads correctly (SVG from `/images/favicon.svg`)

https://claude.ai/code/session_015viy75qm2T9z29gxqSec7X

---
_Generated by [Claude Code](https://claude.ai/code/session_015viy75qm2T9z29gxqSec7X)_