### PR TITLE
Reestructura casos de uso por sector con landings dedicadas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "eraldia",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/cloudflare": "^11.2.0",
+        "@astrojs/cloudflare": "11",
         "@astrojs/rss": "^4.0.11",
         "@astrojs/sitemap": "^3.2.1",
         "astro": "^4.16.18",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -23,4 +23,31 @@ const servicios = defineCollection({
   }),
 });
 
-export const collections = { blog, servicios };
+const sectores = defineCollection({
+  type: 'content',
+  schema: z.object({
+    // Título de la ficha y H1 de la landing
+    title: z.string(),
+    // Etiqueta corta del sector (badge de la tarjeta)
+    badge: z.string(),
+    // Texto de la tarjeta y entradilla de la landing
+    description: z.string(),
+    // Meta description para SEO (si se omite, se usa `description`)
+    metaDescription: z.string().optional(),
+    // Imagen de la tarjeta (opcional: sin ella se muestra un marcador de marca)
+    image: z.string().optional(),
+    imageAlt: z.string().optional(),
+    // Viñetas de automatizaciones en la tarjeta
+    bullets: z.array(z.string()).default([]),
+    // KPIs / resultados destacados
+    kpis: z.array(z.string()).default([]),
+    // Orden (menor = primero). También fija la prioridad estratégica.
+    weight: z.number().default(99),
+    // Sector prioritario (tier 1): se resalta en la rejilla
+    featured: z.boolean().default(false),
+    // Preguntas frecuentes (se vuelcan también a schema FAQPage)
+    faqs: z.array(z.object({ q: z.string(), a: z.string() })).default([]),
+  }),
+});
+
+export const collections = { blog, servicios, sectores };

--- a/src/content/sectores/abogados.md
+++ b/src/content/sectores/abogados.md
@@ -1,0 +1,42 @@
+---
+title: "IA para despachos de abogados"
+badge: "Legal"
+description: "Mucho documento, muchos plazos y horas facturables que se van en tareas administrativas. La IA se ocupa de lo repetitivo para que el despacho dedique el tiempo a lo jurídico."
+metaDescription: "Automatización con IA para despachos de abogados: revisión y resumen de documentos, control de plazos procesales y respuesta a consultas e intake de clientes. Precio cerrado desde 1.900 €."
+weight: 5
+featured: false
+bullets:
+  - "Resumen y búsqueda dentro de expedientes y contratos"
+  - "Control de plazos procesales con avisos automáticos"
+  - "Intake de clientes y respuestas a consultas repetitivas"
+kpis:
+  - "Horas administrativas ↓"
+  - "Plazos controlados ↑"
+faqs:
+  - q: "¿La IA da asesoramiento jurídico?"
+    a: "No. Asiste en lo repetitivo —resumir un expediente, localizar una cláusula, preparar un borrador inicial, ordenar documentación— para ahorrar horas administrativas. El criterio jurídico y la responsabilidad son siempre del abogado."
+  - q: "¿Qué pasa con la confidencialidad y el secreto profesional?"
+    a: "Es el punto crítico y se trata como tal: herramientas que cumplen RGPD, datos que solo se mueven entre tus sistemas y credenciales a tu nombre. En el diagnóstico se define qué información puede tratarse y cómo, antes de montar nada."
+  - q: "¿Cuánto cuesta y cuánto tarda?"
+    a: "El diagnóstico (desde 490 €) prioriza en dos semanas las automatizaciones con más retorno. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026)."
+---
+
+## Menos horas administrativas, más horas facturables
+
+En un despacho, buena parte del día se va en tareas que no son ejercer la abogacía: leer y resumir documentación, buscar una cláusula entre cientos de páginas, controlar plazos, preparar borradores rutinarios y atender las mismas consultas iniciales una y otra vez. Son horas que no se facturan y que, además, queman.
+
+La automatización con IA se ocupa de ese trabajo repetitivo —siempre bajo tu supervisión— para que el tiempo del despacho se dedique a lo jurídico.
+
+## Las automatizaciones que más horas devuelven
+
+- **Resumen y búsqueda en documentos.** Resúmenes de expedientes y contratos largos, localización de cláusulas y datos concretos, comparación de versiones. Lo que antes era una tarde de lectura, en minutos —para revisar, no para confiar a ciegas.
+- **Control de plazos procesales.** Avisos automáticos de vencimientos y señalamientos para que ningún plazo dependa de que alguien se acuerde.
+- **Intake y consultas repetitivas.** Un asistente que recoge los datos del cliente nuevo y responde las preguntas iniciales de siempre, y deriva al abogado lo que requiere criterio.
+
+## Por qué encaja con un despacho
+
+El trabajo legal es intensivo en documento y en plazo, con tarifas por hora altas: cada hora administrativa que se recupera vale mucho. Y como las tareas se repiten entre casos, una automatización bien acotada rinde en todos los expedientes siguientes. El despacho gana las mismas horas que la gestoría, aplicadas a su materia.
+
+## Cómo lo hacemos
+
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €), con especial cuidado en qué información puede tratarse y cómo. La [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), precio cerrado, con las herramientas a tu nombre. ¿Lo vemos? [Hablamos 30 minutos, gratis](/#contacto).

--- a/src/content/sectores/clinicas.md
+++ b/src/content/sectores/clinicas.md
@@ -1,0 +1,47 @@
+---
+title: "IA para clínicas y centros de salud"
+badge: "Salud"
+description: "Dentistas, fisios, veterinarias... Los pacientes esperan respuesta inmediata y el personal no da abasto. La IA atiende lo repetitivo y reduce las ausencias."
+metaDescription: "Automatización con IA para clínicas dentales, de fisioterapia y veterinarias: citas con recordatorios que reducen ausencias, asistente para dudas frecuentes y seguimiento de tratamientos. Precio cerrado desde 1.900 €."
+image: "/images/use-cases/healthcare.jpg"
+imageAlt: "Equipo de una clínica usando herramientas digitales"
+weight: 2
+featured: true
+bullets:
+  - "Citas automatizadas con recordatorios que reducen ausencias"
+  - "Asistente de IA para dudas frecuentes y pre-triaje"
+  - "Seguimiento automático de tratamientos y revisiones"
+kpis:
+  - "Ausencias ↓"
+  - "Tiempo de respuesta ↓"
+faqs:
+  - q: "¿Cómo reduce las ausencias exactamente?"
+    a: "Con confirmaciones y recordatorios automáticos por WhatsApp o SMS antes de la cita, y opción de reagendar sin llamar. Cada hueco que se recupera es dinero directo: un no-show es una franja perdida que ya no vuelve."
+  - q: "¿La IA da consejo médico a los pacientes?"
+    a: "No. El asistente resuelve dudas administrativas y de organización (horarios, precios orientativos, qué traer, cómo llegar) y hace un pre-triaje sencillo para derivar; las decisiones clínicas son siempre del profesional."
+  - q: "¿Se integra con mi software de citas?"
+    a: "En la mayoría de casos sí, o se conecta con la agenda y el WhatsApp que ya usáis. En el diagnóstico se comprueba antes de prometer nada."
+  - q: "¿Cumple con la protección de datos de salud?"
+    a: "Se trabaja con herramientas que cumplen RGPD y los datos de pacientes se tratan con el cuidado que exige el dato de salud. Las credenciales y el sistema quedan a tu nombre."
+---
+
+## El minuto que tu equipo no tiene, lo pone la automatización
+
+En una clínica el teléfono no para, el WhatsApp tampoco, y mientras tanto hay pacientes en consulta. El resultado: llamadas sin contestar, mensajes que se quedan sin respuesta horas y huecos que se pierden por ausencias que nadie llegó a confirmar. No es un problema de actitud del equipo; es un problema de volumen.
+
+La automatización con IA se ocupa de lo repetitivo —confirmar, recordar, responder lo de siempre— para que el personal se dedique a los pacientes.
+
+## Las automatizaciones que más impacto tienen en una clínica
+
+- **Citas y recordatorios que reducen ausencias.** Confirmación automática al reservar, recordatorio el día antes y opción de reagendar sin llamar. Es la automatización con el retorno más claro: cada no-show evitado es una franja que se recupera.
+- **Asistente para dudas frecuentes y pre-triaje.** Responde por web o WhatsApp a las preguntas de siempre (horarios, precios orientativos, qué traer, primeras visitas) y deriva al equipo solo lo que lo necesita.
+- **Seguimiento de tratamientos y revisiones.** Avisos automáticos para revisiones, recordatorios de la siguiente sesión y mensajes de seguimiento que mejoran la adherencia y hacen que el paciente vuelva.
+- **Captación de opiniones.** Pedir la reseña en el momento justo, sin perseguir a nadie, para mejorar la reputación online de la clínica.
+
+## Por qué encaja tan bien con una clínica
+
+El flujo de una clínica dental, una de fisioterapia o una veterinaria es muy parecido: pedir cita, confirmar, recordar, atender, hacer seguimiento. Como el proceso se repite con cada paciente, una automatización bien montada trabaja todo el día sin sumar carga al equipo, y el ahorro (huecos recuperados, llamadas que ya no hay que devolver) se mide desde la primera semana.
+
+## Cómo lo hacemos
+
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €): en dos semanas tienes claras las 2-3 automatizaciones con más impacto y su coste cerrado. Si seguimos, la [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), con el equipo formado y un mes de soporte. Las herramientas se contratan a tu nombre.

--- a/src/content/sectores/gestorias.md
+++ b/src/content/sectores/gestorias.md
@@ -1,0 +1,47 @@
+---
+title: "IA para gestorías, asesorías y despachos"
+badge: "Gestorías"
+description: "Donde más papel y más plazos hay, más se nota la automatización con IA. Menos picado, menos consultas repetidas y cierres sin agobios."
+metaDescription: "Automatización con IA para gestorías y asesorías: procesado de facturas y nóminas, recordatorios de plazos a clientes y respuestas a consultas repetitivas. Precio cerrado desde 1.900 €."
+image: "/images/use-cases/legal.jpg"
+imageAlt: "Profesional de una gestoría trabajando con expedientes"
+weight: 1
+featured: true
+bullets:
+  - "Facturas y nóminas que se procesan solas"
+  - "Recordatorios automáticos de plazos e impuestos a clientes"
+  - "Respuestas asistidas por IA a las consultas repetitivas"
+kpis:
+  - "Horas de picado ↓"
+  - "Plazos cumplidos ↑"
+faqs:
+  - q: "¿Tengo que cambiar de programa de gestión?"
+    a: "No. Las automatizaciones se conectan a lo que ya usas (tu software de contabilidad o nóminas, correo, Excel) sin obligarte a migrar. El objetivo es quitar trabajo manual, no montarte una reforma."
+  - q: "¿Es seguro con datos fiscales y de clientes?"
+    a: "Sí. Se trabaja con herramientas que cumplen RGPD, las credenciales se contratan a tu nombre y los datos sensibles solo se mueven entre tus sistemas. Tú eres el dueño de todo lo que se monta."
+  - q: "¿Cuánto se tarda y cuánto cuesta?"
+    a: "Un diagnóstico (desde 490 €) te dice en dos semanas qué procesos compensa automatizar y cuánto ahorras. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026)."
+  - q: "¿Sirve para una gestoría pequeña?"
+    a: "Especialmente. Cuanto más pesa el trabajo repetitivo sobre pocas personas, más se nota recuperar horas en cada cierre. No hace falta tener un gran departamento de sistemas."
+---
+
+## El sector donde la automatización con IA paga más rápido
+
+Una gestoría vive de plazos y de papel: facturas que picar, nóminas que cuadrar, modelos que presentar antes de una fecha y las mismas preguntas de clientes una y otra vez. Es justo el tipo de trabajo —repetitivo, con reglas claras y mucho volumen— en el que la automatización con IA da el retorno más rápido y más medible de cualquier sector.
+
+No se trata de cambiar tu forma de trabajar ni tu programa de gestión. Se trata de quitar de en medio las horas que se van en tareas que no necesitan tu criterio profesional.
+
+## Las automatizaciones que más liberan en una gestoría
+
+- **Procesado de facturas y nóminas.** La IA extrae los datos de facturas, albaranes y documentos que te llegan en PDF o foto, los deja listos para tu programa y avisa de lo que no cuadra. Se acaba el picado manual a mano.
+- **Recordatorios de plazos a clientes.** Avisos automáticos de impuestos, vencimientos y documentación pendiente, con el tono de tu despacho. Menos clientes que se despistan, menos correos tuyos persiguiéndoles.
+- **Respuestas a consultas repetitivas.** Un asistente que contesta por correo o WhatsApp las preguntas de siempre ("¿qué necesitas para la renta?", "¿cuándo sale la nómina?") y solo te pasa lo que de verdad requiere a un profesional.
+- **Onboarding de cliente nuevo.** Recogida de documentación, altas y carpetas montadas sin que nadie del equipo tenga que ir paso a paso.
+
+## Por qué encaja tan bien con una gestoría
+
+El trabajo está estructurado y se repite cada mes y cada trimestre: en cuanto una automatización funciona para un cierre, funciona para todos los siguientes. Además, **cada gestoría tiene decenas de clientes pyme** a los que estas mismas automatizaciones también les vienen bien: lo que montas para tu despacho te abre la conversación con ellos.
+
+## Cómo lo hacemos
+
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €): en dos semanas tienes el mapa de tus procesos, las 2-3 automatizaciones con más ahorro y su coste cerrado. Si seguimos, la [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), con tu equipo formado y un mes de soporte incluido. Las herramientas se contratan a tu nombre: el sistema es tuyo.

--- a/src/content/sectores/gimnasios.md
+++ b/src/content/sectores/gimnasios.md
@@ -1,0 +1,40 @@
+---
+title: "IA para gimnasios y centros deportivos"
+badge: "Deporte"
+description: "El crecimiento depende del seguimiento constante y de la retención de socios. La IA hace ese seguimiento que, con el día a día, siempre se queda a medias."
+metaDescription: "Automatización con IA para gimnasios y centros deportivos: seguimiento automático de interesados, bienvenida personalizada y señales de abandono para reducir bajas. Precio cerrado desde 1.900 €."
+image: "/images/use-cases/fitness.jpg"
+imageAlt: "Socio de gimnasio entrenando con su monitor"
+weight: 3
+featured: false
+bullets:
+  - "Seguimiento automático de interesados en pruebas y visitas"
+  - "Alta y bienvenida automatizadas con plan personalizado"
+  - "Señales de abandono que avisan antes de la baja"
+kpis:
+  - "Pruebas convertidas ↑"
+  - "Bajas ↓"
+faqs:
+  - q: "¿Esto no enfría el trato personal con el socio?"
+    a: "Al revés: automatizar el seguimiento rutinario libera tiempo del equipo para el trato que de verdad importa. La máquina se ocupa de no dejar a nadie sin respuesta; las personas, de la relación."
+  - q: "¿Cómo detecta que un socio se va a dar de baja?"
+    a: "Con señales como la caída de asistencia o la falta de reserva de clases. Cuando aparecen, salta un aviso para que el equipo actúe a tiempo, en vez de enterarse cuando ya ha pedido la baja."
+  - q: "¿Cuánto cuesta y en cuánto tiempo funciona?"
+    a: "El diagnóstico (desde 490 €) prioriza en dos semanas lo que más mueve la aguja. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026)."
+---
+
+## El crecimiento de un gimnasio se cae por el seguimiento
+
+Entra mucha gente a probar, pero buena parte no vuelve. Y de los que se apuntan, una parte se enfría y acaba dándose de baja. No suele ser por el servicio: es porque el seguimiento —ese mensaje a tiempo al que vino a una prueba, esa llamada al socio que lleva tres semanas sin aparecer— es lo primero que se cae cuando el equipo está liado con la sala.
+
+La automatización se ocupa de ese seguimiento constante que nunca falla por falta de tiempo.
+
+## Las automatizaciones que más mueven la aguja
+
+- **Seguimiento de interesados.** Al que vino a una prueba o pidió información se le hace seguimiento automático en el momento justo, con el mensaje adecuado, hasta convertir o descartar. Sin leads olvidados en una libreta.
+- **Alta y bienvenida automatizadas.** El socio nuevo recibe su bienvenida, su plan inicial y los primeros pasos sin que nadie tenga que montarlo a mano. Buen arranque = más permanencia.
+- **Señales de abandono.** El sistema detecta caídas de asistencia o de reservas y avisa al equipo antes de la baja, cuando todavía se puede hacer algo.
+
+## Cómo lo hacemos
+
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €) que prioriza dónde está el mayor retorno: captación, conversión o retención. La [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), con el equipo formado y las herramientas a tu nombre.

--- a/src/content/sectores/inmobiliarias.md
+++ b/src/content/sectores/inmobiliarias.md
@@ -1,0 +1,38 @@
+---
+title: "IA para inmobiliarias y agentes"
+badge: "Inmobiliario"
+description: "Quien responde primero, se lleva la operación. La IA cualifica y sigue cada contacto al momento, para que ningún lead se enfríe en la bandeja de entrada."
+metaDescription: "Automatización con IA para inmobiliarias y agentes: respuesta inmediata y cualificación de leads, seguimiento automático de interesados y publicación de inmuebles sin picar datos. Precio cerrado desde 1.900 €."
+weight: 4
+featured: false
+bullets:
+  - "Respuesta inmediata y cualificación de cada lead, 24/7"
+  - "Seguimiento automático de interesados hasta la visita"
+  - "Fichas e inmuebles publicados sin picar datos a mano"
+kpis:
+  - "Leads atendidos ↑"
+  - "Tiempo de respuesta ↓"
+faqs:
+  - q: "¿La IA habla con el comprador por mí?"
+    a: "Responde al instante a la primera consulta, cualifica (presupuesto, zona, plazos) y agenda la visita o te pasa el lead caliente. El cierre y la relación los llevas tú; la IA evita que el contacto se enfríe esperando respuesta."
+  - q: "¿Se conecta con mi CRM inmobiliario y los portales?"
+    a: "En la mayoría de casos sí: el lead entra cualificado en tu CRM y las fichas se preparan para los portales sin picar dos veces. En el diagnóstico se valida con tus herramientas antes de comprometer nada."
+  - q: "¿Vale para una agencia pequeña o un agente independiente?"
+    a: "Sí. Es justo donde más se nota: un agente solo no puede contestar al instante a todas horas, y ahí es donde se pierden operaciones. La automatización cubre ese hueco sin contratar a nadie."
+---
+
+## En inmobiliario gana quien responde primero
+
+Un comprador que pregunta por un piso suele estar mirando otros cinco a la vez. Quien le responde primero y le hace sentir atendido parte con ventaja; quien tarda horas, ya llega tarde. El problema es que un agente no puede estar contestando al instante mientras enseña pisos, negocia y firma. Por eso se pierden leads que costó dinero conseguir.
+
+La automatización con IA cubre exactamente ese hueco: atención inmediata y seguimiento que no falla.
+
+## Las automatizaciones que más operaciones salvan
+
+- **Respuesta y cualificación inmediata.** Cada consulta —de portal, web o WhatsApp— recibe respuesta al momento, se cualifica (presupuesto, zona, plazos) y se agenda la visita o se te pasa ya caliente. 24/7, también el fin de semana.
+- **Seguimiento automático de interesados.** Al que vio un inmueble y no decidió se le hace seguimiento en el momento justo, con propiedades parecidas, hasta la visita o el descarte. Sin leads olvidados.
+- **Fichas e inmuebles sin picar a mano.** Preparar la ficha, redactar el anuncio y dejarlo listo para los portales a partir de los datos del inmueble, sin teclear lo mismo en cinco sitios.
+
+## Cómo lo hacemos
+
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €) que identifica dónde se te escapan más operaciones. La [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), precio cerrado, con las herramientas a tu nombre. ¿Encaja en tu agencia? [Hablamos 30 minutos, gratis](/#contacto).

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -142,6 +142,17 @@ const currentYear = new Date().getFullYear();
             </div>
 
             <div class="footer__nav-group">
+              <div class="footer__nav-title">Sectores</div>
+              <ul class="footer__nav-list">
+                <li><a href={url('/casos/gestorias/')} class="footer__nav-link">Gestorías y asesorías</a></li>
+                <li><a href={url('/casos/clinicas/')} class="footer__nav-link">Clínicas y centros de salud</a></li>
+                <li><a href={url('/casos/gimnasios/')} class="footer__nav-link">Gimnasios y centros deportivos</a></li>
+                <li><a href={url('/casos/inmobiliarias/')} class="footer__nav-link">Inmobiliarias</a></li>
+                <li><a href={url('/casos/abogados/')} class="footer__nav-link">Despachos de abogados</a></li>
+              </ul>
+            </div>
+
+            <div class="footer__nav-group">
               <div class="footer__nav-title">Eraldia</div>
               <ul class="footer__nav-list">
                 <li><a href={url('/sobre-mi/')} class="footer__nav-link">Sobre mí</a></li>

--- a/src/pages/casos/[slug].astro
+++ b/src/pages/casos/[slug].astro
@@ -1,0 +1,108 @@
+---
+import { url } from '../../utils';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const sectores = await getCollection('sectores');
+  return sectores.map(sector => ({
+    params: { slug: sector.slug },
+    props: { sector },
+  }));
+}
+
+const { sector } = Astro.props;
+const { Content } = await render(sector);
+
+const otros = (await getCollection('sectores'))
+  .filter(s => s.slug !== sector.slug)
+  .sort((a, b) => (a.data.weight ?? 99) - (b.data.weight ?? 99));
+
+const { faqs } = sector.data;
+
+// Schema FAQPage para GEO/SEO (solo si hay preguntas)
+const faqSchema = faqs.length > 0 ? {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(f => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+} : null;
+---
+
+<BaseLayout title={sector.data.title} description={sector.data.metaDescription ?? sector.data.description}>
+
+{faqSchema && <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />}
+
+<div class="page-header">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol class="breadcrumb__list" itemscope itemtype="https://schema.org/BreadcrumbList">
+        <li class="breadcrumb__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+          <a href={url('/')} class="breadcrumb__link" itemprop="item"><span itemprop="name">Inicio</span></a>
+          <meta itemprop="position" content="1">
+        </li>
+        <li class="breadcrumb__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+          <a href={url('/casos/')} class="breadcrumb__link" itemprop="item"><span itemprop="name">Casos de uso</span></a>
+          <meta itemprop="position" content="2">
+        </li>
+        <li class="breadcrumb__item breadcrumb__item--current" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" aria-current="page">
+          <span itemprop="name">{sector.data.title}</span>
+          <meta itemprop="position" content="3">
+        </li>
+      </ol>
+    </nav>
+    <h1 class="page-header__title">{sector.data.title}</h1>
+    <p class="page-header__desc">{sector.data.description}</p>
+    {sector.data.kpis.length > 0 && (
+      <div class="use-case-card__kpis" style="margin-top: 1.5rem;">
+        {sector.data.kpis.map(k => <span class="use-case-card__kpi">{k}</span>)}
+      </div>
+    )}
+  </div>
+</div>
+
+<section class="section">
+  <div class="container container--narrow">
+    <div class="content">
+      <Content />
+    </div>
+
+    {faqs.length > 0 && (
+      <div class="faq" style="margin-top: 3rem;">
+        <h2 class="section__title">Preguntas frecuentes</h2>
+        <div class="faq__list">
+          {faqs.map(f => (
+            <details class="faq__item">
+              <summary class="faq__question">{f.q}</summary>
+              <p class="faq__answer">{f.a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    )}
+
+    <div class="cta cta--inline cta--dark reveal" aria-label="Contacto" style="margin-top: 3rem;">
+      <div class="cta__inner">
+        <h2 class="cta__title">¿Lo vemos en tu caso?</h2>
+        <p class="cta__desc">
+          Cuéntame en dos líneas qué proceso te quita más tiempo y te digo, sin humo, si la IA puede ayudarte y cuánto costaría.
+        </p>
+        <a href={url('/#contacto')} class="btn btn--primary btn--lg">Hablamos 30 minutos, gratis</a>
+      </div>
+    </div>
+
+    <nav class="related-sectores" aria-label="Otros sectores">
+      <h2 class="related-sectores__title">Otros sectores</h2>
+      <ul class="related-sectores__list">
+        {otros.map(s => (
+          <li><a href={url(`/casos/${s.slug}/`)} class="related-sectores__link">{s.data.title}</a></li>
+        ))}
+      </ul>
+    </nav>
+  </div>
+</section>
+
+</BaseLayout>

--- a/src/pages/casos/index.astro
+++ b/src/pages/casos/index.astro
@@ -1,16 +1,20 @@
 ---
 import { url } from '../../utils';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
 
-const title = 'Casos de uso';
-const description = 'Ejemplos concretos de lo que la automatización y la IA pueden hacer en negocios como el tuyo.';
+const title = 'Casos de uso por sector';
+const description = 'Dónde la automatización con IA paga más rápido: ejemplos concretos, automatizaciones y resultados por sector.';
+
+const sectores = await getCollection('sectores');
+sectores.sort((a, b) => (a.data.weight ?? 99) - (b.data.weight ?? 99));
 ---
 
 <BaseLayout title={title} description={description}>
 
 <div class="page-header">
   <div class="container">
-    <h1 class="page-header__title">Casos de uso</h1>
+    <h1 class="page-header__title">Casos de uso por sector</h1>
     <p class="page-header__desc">{description}</p>
   </div>
 </div>
@@ -18,84 +22,37 @@ const description = 'Ejemplos concretos de lo que la automatización y la IA pue
 <section class="section">
   <div class="container container--narrow">
     <div class="use-cases-grid">
-      <article class="card use-case-card">
-        <div class="use-case-card__image">
-          <img src={url('/images/use-cases/healthcare.jpg')} alt="Equipo de una clínica usando herramientas digitales" loading="lazy" decoding="async">
-        </div>
-        <div class="use-case-card__badge">Salud</div>
-        <h2 class="use-case-card__title">Clínicas y centros de salud</h2>
-        <p class="use-case-card__desc">Dentistas, fisios, veterinarias... Los pacientes esperan respuesta inmediata y el personal no da abasto.</p>
-        <ul class="use-case-card__list">
-          <li>Asistente de IA para dudas frecuentes y pre-triaje</li>
-          <li>Citas automatizadas con recordatorios que reducen ausencias</li>
-          <li>Seguimiento automático de tratamientos y revisiones</li>
-        </ul>
-        <div class="use-case-card__kpis">
-          <span class="use-case-card__kpi">Ausencias ↓</span>
-          <span class="use-case-card__kpi">Tiempo de respuesta ↓</span>
-        </div>
-      </article>
-
-      <article class="card use-case-card">
-        <div class="use-case-card__image">
-          <img src={url('/images/use-cases/legal.jpg')} alt="Profesional trabajando con expedientes" loading="lazy" decoding="async">
-        </div>
-        <div class="use-case-card__badge">Gestorías</div>
-        <h2 class="use-case-card__title">Gestorías, asesorías y despachos</h2>
-        <p class="use-case-card__desc">Donde más papel y más plazos hay, más se nota la automatización con IA.</p>
-        <ul class="use-case-card__list">
-          <li>Facturas y nóminas que se procesan solas</li>
-          <li>Recordatorios automáticos de plazos e impuestos a clientes</li>
-          <li>Respuestas asistidas por IA a las consultas repetitivas</li>
-        </ul>
-        <div class="use-case-card__kpis">
-          <span class="use-case-card__kpi">Horas de picado ↓</span>
-          <span class="use-case-card__kpi">Plazos cumplidos ↑</span>
-        </div>
-      </article>
-
-      <article class="card use-case-card">
-        <div class="use-case-card__image">
-          <img src={url('/images/use-cases/hospitality.jpg')} alt="Personal de un restaurante preparando el servicio" loading="lazy" decoding="async">
-        </div>
-        <div class="use-case-card__badge">Hostelería</div>
-        <h2 class="use-case-card__title">Hostelería y restauración</h2>
-        <p class="use-case-card__desc">Equipos que van a tope y clientes que quieren respuesta al momento.</p>
-        <ul class="use-case-card__list">
-          <li>Reservas automatizadas con confirmación instantánea</li>
-          <li>Recogida de opiniones que detecta problemas a tiempo</li>
-          <li>Campañas automáticas para que el cliente vuelva</li>
-        </ul>
-        <div class="use-case-card__kpis">
-          <span class="use-case-card__kpi">Clientes que repiten ↑</span>
-          <span class="use-case-card__kpi">Valoraciones ↑</span>
-        </div>
-      </article>
-
-      <article class="card use-case-card">
-        <div class="use-case-card__image">
-          <img src={url('/images/use-cases/fitness.jpg')} alt="Socio de gimnasio entrenando con su monitor" loading="lazy" decoding="async">
-        </div>
-        <div class="use-case-card__badge">Deporte</div>
-        <h2 class="use-case-card__title">Gimnasios y centros deportivos</h2>
-        <p class="use-case-card__desc">El crecimiento depende del seguimiento constante y de la retención de socios.</p>
-        <ul class="use-case-card__list">
-          <li>Seguimiento automático de interesados en pruebas y visitas</li>
-          <li>Alta y bienvenida automatizadas con plan personalizado</li>
-          <li>Señales de abandono que avisan antes de la baja</li>
-        </ul>
-        <div class="use-case-card__kpis">
-          <span class="use-case-card__kpi">Pruebas convertidas ↑</span>
-          <span class="use-case-card__kpi">Bajas ↓</span>
-        </div>
-      </article>
+      {sectores.map(sector => (
+        <a href={url(`/casos/${sector.slug}/`)} class={`card use-case-card use-case-card--link${sector.data.featured ? ' use-case-card--featured' : ''}`}>
+          {sector.data.featured && <span class="use-case-card__flag">Sector prioritario</span>}
+          {sector.data.image ? (
+            <div class="use-case-card__image">
+              <img src={url(sector.data.image)} alt={sector.data.imageAlt} loading="lazy" decoding="async">
+            </div>
+          ) : (
+            <div class="use-case-card__image use-case-card__image--placeholder" aria-hidden="true">
+              <span>{sector.data.badge}</span>
+            </div>
+          )}
+          <div class="use-case-card__badge">{sector.data.badge}</div>
+          <h2 class="use-case-card__title">{sector.data.title}</h2>
+          <p class="use-case-card__desc">{sector.data.description}</p>
+          <ul class="use-case-card__list">
+            {sector.data.bullets.map(b => <li>{b}</li>)}
+          </ul>
+          <div class="use-case-card__kpis">
+            {sector.data.kpis.map(k => <span class="use-case-card__kpi">{k}</span>)}
+          </div>
+          <span class="card__link">Ver cómo funciona</span>
+        </a>
+      ))}
     </div>
 
     <div class="cta cta--inline cta--dark reveal" aria-label="Contacto" style="margin-top: 3rem;">
       <div class="cta__inner">
         <h2 class="cta__title">¿Tu sector no está aquí?</h2>
         <p class="cta__desc">
-          Estos son solo ejemplos. Si en tu negocio hay tareas repetitivas, hay margen para automatizar. Cuéntamelo y te digo si tiene sentido.
+          Estos son los sectores donde más trabajo, pero no los únicos. Hostelería, comercio, talleres, academias... Si en tu negocio hay tareas repetitivas, hay margen para automatizar. Cuéntamelo y te digo si tiene sentido.
         </p>
         <a href={url('/#contacto')} class="btn btn--primary btn--lg">Hablamos 30 minutos, gratis</a>
       </div>

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -558,6 +558,160 @@
   color: $color-accent-dark;
 }
 
+// Tarjeta de sector como enlace a su landing
+.use-case-card--link {
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    text-decoration: none;
+    color: inherit;
+    transform: translateY(-2px);
+    box-shadow: $shadow-md;
+    border-color: transparent;
+  }
+
+  .card__link {
+    margin-top: $space-4;
+  }
+}
+
+// Sector prioritario (tier 1)
+.use-case-card--featured {
+  border-color: rgba($color-primary, 0.4);
+  border-top: 3px solid $color-primary;
+}
+
+.use-case-card__flag {
+  position: absolute;
+  top: $space-4;
+  right: $space-4;
+  z-index: 1;
+  padding: $space-1 $space-3;
+  font-size: $font-size-xs;
+  font-weight: $font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $color-white;
+  background: $color-primary;
+  border-radius: $border-radius-full;
+  box-shadow: $shadow-sm;
+}
+
+// Marcador para sectores sin foto
+.use-case-card__image--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba($color-primary, 0.12), rgba($color-accent, 0.12));
+
+  span {
+    font-family: $font-heading;
+    font-size: $font-size-xl;
+    font-weight: $font-weight-semibold;
+    color: $color-primary;
+    letter-spacing: 0.02em;
+  }
+}
+
+// --------------------------------------------------------------------------
+// FAQ (landings de sector y posts)
+// --------------------------------------------------------------------------
+.faq__list {
+  margin-top: $space-5;
+  display: flex;
+  flex-direction: column;
+  gap: $space-3;
+}
+
+.faq__item {
+  border: 1px solid $color-border;
+  border-radius: $border-radius-lg;
+  padding: $space-4 $space-5;
+  background: $color-white;
+  transition: border-color $transition-base;
+
+  &[open] {
+    border-color: rgba($color-primary, 0.4);
+  }
+}
+
+.faq__question {
+  font-weight: $font-weight-semibold;
+  color: $color-dark;
+  cursor: pointer;
+  list-style: none;
+  position: relative;
+  padding-right: $space-6;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::after {
+    content: '+';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: $font-size-xl;
+    color: $color-primary;
+    line-height: 1;
+  }
+}
+
+.faq__item[open] .faq__question::after {
+  content: '\2212'; // minus
+}
+
+.faq__answer {
+  margin: $space-3 0 0;
+  color: $color-text-light;
+  line-height: $line-height-base;
+}
+
+// --------------------------------------------------------------------------
+// Otros sectores (interlinking)
+// --------------------------------------------------------------------------
+.related-sectores {
+  margin-top: $space-8;
+  padding-top: $space-6;
+  border-top: 1px solid $color-border;
+}
+
+.related-sectores__title {
+  font-size: $font-size-lg;
+  font-weight: $font-weight-semibold;
+  color: $color-dark;
+  margin-bottom: $space-4;
+}
+
+.related-sectores__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-3;
+}
+
+.related-sectores__link {
+  display: inline-block;
+  padding: $space-2 $space-4;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  color: $color-primary;
+  background: rgba($color-primary, 0.08);
+  border-radius: $border-radius-full;
+  text-decoration: none;
+  transition: background $transition-fast;
+
+  &:hover {
+    background: rgba($color-primary, 0.16);
+    text-decoration: none;
+  }
+}
+
 // --------------------------------------------------------------------------
 // Feature Blocks
 // --------------------------------------------------------------------------


### PR DESCRIPTION
- Nueva colección de contenido `sectores` (re-ranking por `weight`,
  ampliable con un solo .md por sector)
- Hub /casos/ ahora ordenado por prioridad estratégica: gestorías y
  clínicas como sectores prioritarios, gimnasios, e inmobiliarias y
  abogados como verticales de expansión. Hostelería se integra en el CTA
  "¿tu sector no está aquí?" en lugar de tarjeta propia
- Landings de sector en /casos/<slug>/ con KPIs, FAQs y schema FAQPage
  para SEO/GEO, e interlinking entre sectores
- Tarjetas de sector enlazables, con marcador de "sector prioritario" y
  marcador de marca para sectores sin foto
- Grupo "Sectores" en el footer para interlinking desde toda la web

https://claude.ai/code/session_01SXt8223BeV7GWLwsPJEyXR