### PR TITLE
Add Cloudflare D1 database to store website leads

### DIFF
--- a/docs/LEADS-DB.md
+++ b/docs/LEADS-DB.md
@@ -1,0 +1,104 @@
+# Base de datos de leads
+
+Los mensajes del formulario de contacto de la web se guardan en una base de
+datos **Cloudflare D1** (SQLite serverless, plan gratuito). Sustituye a la
+dependencia anterior de Formspree: ahora los datos son tuyos y viven junto al
+worker que sirve la web.
+
+```
+ Formulario (/#contacto)
+   │  POST (fetch o envío normal)
+   ▼
+ /api/lead  ──────────▶  D1 «eraldia-leads» · tabla leads
+   │  (valida + honeypot)
+   ▼
+ /api/leads-export  ◀──  descarga de los leads (JSON o CSV, con token)
+```
+
+## Piezas
+
+| Archivo | Qué hace |
+|---|---|
+| `migrations/0001_create_leads.sql` | Esquema de la tabla `leads`. |
+| `wrangler.jsonc` → `d1_databases` | Enlaza la base con el binding `DB`. |
+| `src/pages/api/lead.ts` | Recibe el formulario, valida y guarda el lead. |
+| `src/pages/api/leads-export.ts` | Descarga los leads (protegido por token). |
+| `src/pages/index.astro` | Formulario que envía a `/api/lead`. |
+
+## Puesta en marcha (una sola vez)
+
+1. **Crear la base** en tu cuenta de Cloudflare:
+
+   ```bash
+   npx wrangler d1 create eraldia-leads
+   ```
+
+   Copia el `database_id` que devuelve y pégalo en `wrangler.jsonc`
+   (campo `database_id`, sustituyendo `REEMPLAZA_CON_EL_DATABASE_ID`).
+
+2. **Aplicar la migración** (crea la tabla en la base remota):
+
+   ```bash
+   npx wrangler d1 migrations apply eraldia-leads --remote
+   ```
+
+3. **Definir el token de exportación** (para poder descargar los leads):
+
+   ```bash
+   npx wrangler secret put LEADS_TOKEN
+   ```
+
+4. **Desplegar**:
+
+   ```bash
+   npm run deploy
+   ```
+
+## Desarrollo local
+
+La base local vive en `.wrangler/` (ignorada por git). Para probar:
+
+```bash
+npx wrangler d1 migrations apply eraldia-leads --local
+npm run preview   # build + wrangler dev
+```
+
+El formulario tiene mejora progresiva: con JS envía por `fetch` y muestra el
+mensaje de éxito sin recargar; sin JS hace un POST normal y el servidor
+redirige a `/?enviado=1#contacto`.
+
+> Nota: en GitHub Pages (despliegue estático) las rutas `/api/*` no se ejecutan.
+> El formulario solo guarda leads en el despliegue de Cloudflare (eraldia.com).
+
+## Consultar los leads
+
+**Desde la terminal** (base remota):
+
+```bash
+npx wrangler d1 execute eraldia-leads --remote \
+  --command="SELECT created_at, nombre, email, negocio FROM leads ORDER BY created_at DESC;"
+```
+
+**Por HTTP** (usando el `LEADS_TOKEN`):
+
+```bash
+# JSON
+curl -H "Authorization: Bearer TU_TOKEN" https://eraldia.com/api/leads-export
+
+# CSV (para abrir en una hoja de cálculo)
+curl -o leads.csv "https://eraldia.com/api/leads-export?format=csv&token=TU_TOKEN"
+```
+
+## Esquema de la tabla `leads`
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | INTEGER | Clave primaria autoincremental. |
+| `nombre` | TEXT | Obligatorio. |
+| `email` | TEXT | Obligatorio, validado. |
+| `negocio` | TEXT | Opcional. |
+| `mensaje` | TEXT | Obligatorio. |
+| `fuente` | TEXT | Referer desde donde se envió. |
+| `user_agent` | TEXT | Navegador. |
+| `ip` | TEXT | `cf-connecting-ip`. |
+| `created_at` | TEXT | Fecha/hora UTC automática. |

--- a/migrations/0001_create_leads.sql
+++ b/migrations/0001_create_leads.sql
@@ -1,0 +1,18 @@
+-- Tabla de leads capturados desde el formulario de contacto de la web.
+-- Aplícala con:  npx wrangler d1 migrations apply eraldia-leads --remote
+-- (o sin --remote para la base local de desarrollo).
+
+CREATE TABLE IF NOT EXISTS leads (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  nombre      TEXT    NOT NULL,
+  email       TEXT    NOT NULL,
+  negocio     TEXT,
+  mensaje     TEXT    NOT NULL,
+  fuente      TEXT,                 -- página/referer desde donde se envió
+  user_agent  TEXT,
+  ip          TEXT,                 -- cf-connecting-ip
+  created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_leads_created_at ON leads (created_at);
+CREATE INDEX IF NOT EXISTS idx_leads_email      ON leads (email);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,7 +11,7 @@ export const AUTHOR = 'Gorka Alapont';
 // TODO: cambiar por hola@eraldia.com cuando el dominio y el reenvío de correo estén activos
 export const CONTACT_EMAIL = 'alapontgorka@gmail.com';
 
-// TODO: crear el formulario en https://formspree.io (gratis) y pegar aquí el ID (p. ej. "xqkrgyzb")
-export const FORMSPREE_ID = '';
+// El formulario de contacto guarda los leads en la base de datos D1 a través de
+// /api/lead. Ver docs/LEADS-DB.md, wrangler.jsonc y migrations/.
 
 export const LINKEDIN_URL = '';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,16 @@
 /// <reference path="../.astro/types.d.ts" />
+
+// Bindings de Cloudflare disponibles en `Astro.locals.runtime.env`.
+interface Env {
+  // Base de datos de leads (D1). Ver wrangler.jsonc y migrations/.
+  DB: import('@cloudflare/workers-types').D1Database;
+  // Token para proteger la exportación de leads (/api/leads-export).
+  // Configúralo con: npx wrangler secret put LEADS_TOKEN
+  LEADS_TOKEN?: string;
+}
+
+type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
+
+declare namespace App {
+  interface Locals extends Runtime {}
+}

--- a/src/pages/api/lead.ts
+++ b/src/pages/api/lead.ts
@@ -1,0 +1,96 @@
+import type { APIRoute, APIContext } from 'astro';
+
+// Ruta de servidor: se ejecuta en Cloudflare, no se prerenderiza.
+export const prerender = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Base del despliegue ('/' en Cloudflare). Se usa para las redirecciones.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const clean = (value: unknown, max: number): string =>
+  (value ?? '').toString().trim().slice(0, max);
+
+const json = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+
+const ok = (wantsJson: boolean, redirect: APIContext['redirect']): Response =>
+  wantsJson ? json({ ok: true }, 200) : redirect(`${BASE}/?enviado=1#contacto`, 303);
+
+const fail = (
+  message: string,
+  status: number,
+  wantsJson: boolean,
+  redirect: APIContext['redirect'],
+): Response =>
+  wantsJson ? json({ ok: false, error: message }, status) : redirect(`${BASE}/?error=1#contacto`, 303);
+
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const wantsJson = (request.headers.get('accept') ?? '').includes('application/json');
+  const contentType = request.headers.get('content-type') ?? '';
+
+  let raw: Record<string, unknown> = {};
+  try {
+    if (contentType.includes('application/json')) {
+      raw = await request.json();
+    } else {
+      const form = await request.formData();
+      raw = {
+        nombre: form.get('nombre'),
+        email: form.get('email'),
+        negocio: form.get('negocio'),
+        mensaje: form.get('mensaje'),
+        _gotcha: form.get('_gotcha'),
+      };
+    }
+  } catch {
+    return fail('No he podido leer el formulario.', 400, wantsJson, redirect);
+  }
+
+  // Honeypot anti-spam: si el campo oculto viene relleno es un bot.
+  // Fingimos éxito y no guardamos nada.
+  if (clean(raw._gotcha, 200)) {
+    return ok(wantsJson, redirect);
+  }
+
+  const nombre = clean(raw.nombre, 200);
+  const email = clean(raw.email, 320);
+  const negocio = clean(raw.negocio, 200);
+  const mensaje = clean(raw.mensaje, 4000);
+
+  if (!nombre || !email || !mensaje || !EMAIL_RE.test(email)) {
+    return fail('Revisa el nombre, el email y el mensaje.', 422, wantsJson, redirect);
+  }
+
+  const db = locals.runtime?.env?.DB;
+  if (!db) {
+    console.error('[lead] Falta el binding D1 "DB". ¿Has configurado wrangler.jsonc?');
+    return fail('El formulario no está disponible ahora mismo.', 503, wantsJson, redirect);
+  }
+
+  try {
+    await db
+      .prepare(
+        `INSERT INTO leads (nombre, email, negocio, mensaje, fuente, user_agent, ip)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        nombre,
+        email,
+        negocio || null,
+        mensaje,
+        request.headers.get('referer'),
+        request.headers.get('user-agent'),
+        request.headers.get('cf-connecting-ip'),
+      )
+      .run();
+  } catch (err) {
+    console.error('[lead] Error guardando el lead:', err);
+    return fail('No he podido guardar tu mensaje. Inténtalo de nuevo.', 500, wantsJson, redirect);
+  }
+
+  return ok(wantsJson, redirect);
+};

--- a/src/pages/api/leads-export.ts
+++ b/src/pages/api/leads-export.ts
@@ -1,0 +1,66 @@
+import type { APIRoute } from 'astro';
+
+// Ruta de servidor protegida por token. Descarga los leads en JSON o CSV:
+//   curl -H "Authorization: Bearer TU_TOKEN" https://eraldia.com/api/leads-export
+//   https://eraldia.com/api/leads-export?format=csv&token=TU_TOKEN
+export const prerender = false;
+
+interface LeadRow {
+  id: number;
+  nombre: string;
+  email: string;
+  negocio: string | null;
+  mensaje: string;
+  fuente: string | null;
+  user_agent: string | null;
+  ip: string | null;
+  created_at: string;
+}
+
+const csvCell = (value: unknown): string => {
+  const text = (value ?? '').toString();
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+};
+
+export const GET: APIRoute = async ({ request, locals, url }) => {
+  const env = locals.runtime?.env;
+  const token = env?.LEADS_TOKEN;
+
+  const provided =
+    request.headers.get('authorization')?.replace(/^Bearer\s+/i, '').trim() ??
+    url.searchParams.get('token') ??
+    '';
+
+  if (!token || provided !== token) {
+    return new Response('No autorizado', { status: 401 });
+  }
+
+  const db = env?.DB;
+  if (!db) {
+    return new Response('Base de datos no configurada', { status: 503 });
+  }
+
+  const { results } = await db
+    .prepare('SELECT * FROM leads ORDER BY created_at DESC')
+    .all<LeadRow>();
+
+  if (url.searchParams.get('format') === 'csv') {
+    const columns: (keyof LeadRow)[] = [
+      'id', 'created_at', 'nombre', 'email', 'negocio', 'mensaje', 'fuente', 'user_agent', 'ip',
+    ];
+    const lines = [
+      columns.join(','),
+      ...results.map((row) => columns.map((col) => csvCell(row[col])).join(',')),
+    ];
+    return new Response(lines.join('\n'), {
+      headers: {
+        'content-type': 'text/csv; charset=utf-8',
+        'content-disposition': 'attachment; filename="leads.csv"',
+      },
+    });
+  }
+
+  return new Response(JSON.stringify({ count: results.length, leads: results }, null, 2), {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { url } from '../utils';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts';
 ---
 
 <BaseLayout
@@ -191,42 +191,89 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } fr
       </p>
     </div>
 
-    {FORMSPREE_ID ? (
-      <form class="contact-form reveal" action={`https://formspree.io/f/${FORMSPREE_ID}`} method="POST">
-        <div class="contact-form__row">
-          <div class="contact-form__field">
-            <label for="cf-nombre" class="contact-form__label">Nombre</label>
-            <input type="text" id="cf-nombre" name="nombre" class="contact-form__input" required autocomplete="name">
-          </div>
-          <div class="contact-form__field">
-            <label for="cf-email" class="contact-form__label">Email</label>
-            <input type="email" id="cf-email" name="email" class="contact-form__input" required autocomplete="email">
-          </div>
+    <div class="contact-form__success reveal" id="contact-success" hidden>
+      <h3 class="contact-form__success-title">¡Gracias! He recibido tu mensaje.</h3>
+      <p class="contact-form__success-text">
+        Te respondo en menos de 24 horas laborables con los siguientes pasos. Si es urgente,
+        escríbeme a <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+      </p>
+    </div>
+
+    <form class="contact-form reveal" id="contact-form" action={url('/api/lead')} method="POST">
+      <p class="contact-form__error" id="contact-error" role="alert" hidden>
+        No he podido enviar tu mensaje. Inténtalo de nuevo o escríbeme directamente a
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+      </p>
+      <div class="contact-form__row">
+        <div class="contact-form__field">
+          <label for="cf-nombre" class="contact-form__label">Nombre</label>
+          <input type="text" id="cf-nombre" name="nombre" class="contact-form__input" required autocomplete="name">
         </div>
         <div class="contact-form__field">
-          <label for="cf-negocio" class="contact-form__label">¿A qué se dedica tu negocio?</label>
-          <input type="text" id="cf-negocio" name="negocio" class="contact-form__input" placeholder="Ej.: clínica dental, gestoría, tienda online...">
-        </div>
-        <div class="contact-form__field">
-          <label for="cf-mensaje" class="contact-form__label">¿Qué proceso te quita más tiempo?</label>
-          <textarea id="cf-mensaje" name="mensaje" class="contact-form__textarea" rows="4" required placeholder="Ej.: contestar siempre las mismas preguntas por WhatsApp, hacer presupuestos, pasar facturas a mano..."></textarea>
-        </div>
-        {/* Honeypot anti-spam */}
-        <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
-        <button type="submit" class="btn btn--primary btn--lg contact-form__submit">Enviar y reservar mi llamada gratuita</button>
-        <p class="contact-form__note">Al enviar aceptas que use estos datos solo para responderte. Nada de newsletters sorpresa.</p>
-      </form>
-    ) : (
-      <div class="cta cta--inline cta--dark reveal" aria-label="Contacto por correo">
-        <div class="cta__inner">
-          <h2 class="cta__title">Escríbeme directamente</h2>
-          <p class="cta__desc">
-            Mándame un correo con dos líneas sobre tu negocio y el proceso que más tiempo te quita. Te respondo en menos de 24 horas laborables.
-          </p>
-          <a href={`mailto:${CONTACT_EMAIL}?subject=Llamada%20gratuita%20de%2030%20minutos`} class="btn btn--primary btn--lg">Enviar correo</a>
+          <label for="cf-email" class="contact-form__label">Email</label>
+          <input type="email" id="cf-email" name="email" class="contact-form__input" required autocomplete="email">
         </div>
       </div>
-    )}
+      <div class="contact-form__field">
+        <label for="cf-negocio" class="contact-form__label">¿A qué se dedica tu negocio?</label>
+        <input type="text" id="cf-negocio" name="negocio" class="contact-form__input" placeholder="Ej.: clínica dental, gestoría, tienda online...">
+      </div>
+      <div class="contact-form__field">
+        <label for="cf-mensaje" class="contact-form__label">¿Qué proceso te quita más tiempo?</label>
+        <textarea id="cf-mensaje" name="mensaje" class="contact-form__textarea" rows="4" required placeholder="Ej.: contestar siempre las mismas preguntas por WhatsApp, hacer presupuestos, pasar facturas a mano..."></textarea>
+      </div>
+      {/* Honeypot anti-spam */}
+      <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
+      <button type="submit" class="btn btn--primary btn--lg contact-form__submit">Enviar y reservar mi llamada gratuita</button>
+      <p class="contact-form__note">Al enviar aceptas que use estos datos solo para responderte. Nada de newsletters sorpresa.</p>
+    </form>
+
+    <script is:inline>
+      (function () {
+        var form = document.getElementById('contact-form');
+        var success = document.getElementById('contact-success');
+        var error = document.getElementById('contact-error');
+        if (!form) return;
+
+        function showSuccess() {
+          if (success) success.hidden = false;
+          form.hidden = true;
+          (success || form).scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+
+        // Si volvemos de una redirección del servidor (sin JS), refleja el estado.
+        var params = new URLSearchParams(window.location.search);
+        if (params.get('enviado') === '1') showSuccess();
+        if (params.get('error') === '1' && error) error.hidden = false;
+
+        // Mejora progresiva: enviar por fetch para no recargar la página.
+        form.addEventListener('submit', function (event) {
+          event.preventDefault();
+          if (error) error.hidden = true;
+          var button = form.querySelector('button[type="submit"]');
+          if (button) button.disabled = true;
+
+          fetch(form.action, {
+            method: 'POST',
+            headers: { Accept: 'application/json' },
+            body: new FormData(form),
+          })
+            .then(function (res) {
+              if (res.ok) {
+                showSuccess();
+              } else if (error) {
+                error.hidden = false;
+              }
+            })
+            .catch(function () {
+              if (error) error.hidden = false;
+            })
+            .finally(function () {
+              if (button) button.disabled = false;
+            });
+        });
+      })();
+    </script>
   </div>
 </section>
 

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -1067,4 +1067,45 @@
     text-align: center;
     margin: $space-3 0 0;
   }
+
+  &__error {
+    background: rgba($color-accent, 0.1);
+    border: 1px solid rgba($color-accent, 0.4);
+    color: darken($color-accent, 20%);
+    border-radius: $border-radius;
+    padding: $space-3 $space-4;
+    font-size: $font-size-sm;
+    margin: 0 0 $space-4;
+
+    a {
+      color: inherit;
+      font-weight: $font-weight-semibold;
+    }
+  }
+
+  &__success {
+    max-width: 640px;
+    margin: 0 auto;
+    background: $color-white;
+    border: 1px solid $color-primary;
+    border-radius: $border-radius-xl;
+    padding: $space-7;
+    box-shadow: $shadow-md;
+    text-align: center;
+
+    &-title {
+      color: $color-primary;
+      margin: 0 0 $space-3;
+    }
+
+    &-text {
+      color: $color-text;
+      margin: 0;
+
+      a {
+        color: $color-primary;
+        font-weight: $font-weight-semibold;
+      }
+    }
+  }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,7 @@
     {
       "binding": "DB",
       "database_name": "eraldia-leads",
-      "database_id": "REEMPLAZA_CON_EL_DATABASE_ID",
+      "database_id": "57d52d04-21f0-46ae-b22e-c56eebd0ffa3",
       "migrations_dir": "migrations"
     }
   ]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,5 +13,16 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "dist"
-  }
+  },
+  // Base de datos de leads (Cloudflare D1). Crea la base con:
+  //   npx wrangler d1 create eraldia-leads
+  // y pega el "database_id" que devuelve en el campo de abajo.
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "eraldia-leads",
+      "database_id": "REEMPLAZA_CON_EL_DATABASE_ID",
+      "migrations_dir": "migrations"
+    }
+  ]
 }


### PR DESCRIPTION
Replace the (unconfigured) Formspree dependency with a self-hosted lead store on Cloudflare D1:

- migrations/0001_create_leads.sql: leads table schema
- wrangler.jsonc: D1 binding (DB)
- src/pages/api/lead.ts: validates + stores submissions (honeypot, email check)
- src/pages/api/leads-export.ts: token-protected JSON/CSV export
- index.astro: contact form posts to /api/lead with progressive enhancement
- docs/LEADS-DB.md: setup and query guide

https://claude.ai/code/session_01Vg2BEDpR5uKsuiXUB84XpT