### PR TITLE
Header claro sin degradado

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -135,13 +135,8 @@
 
 .header--on-hero,
 .header--light {
-  border-bottom-color: rgba($color-white, 0.12);
-  background: linear-gradient(
-    135deg,
-    $color-dark 0%,
-    $color-primary 55%,
-    $color-dark 100%
-  );
+  border-bottom-color: $color-border;
+  background-color: rgba($color-light, 0.85);
 }
 
 .header__inner {
@@ -208,11 +203,6 @@
   margin: 0 auto;
 }
 
-.header--on-hero .header__toggle-bar,
-.header--light .header__toggle-bar {
-  background-color: $color-white;
-}
-
 .header__nav {
   display: flex;
   align-items: center;
@@ -244,31 +234,6 @@
     outline-offset: 2px;
     background-color: rgba($color-primary, 0.1);
   }
-}
-
-.header--on-hero .header__logo,
-.header--on-hero .header__nav-link,
-.header--light .header__logo,
-.header--light .header__nav-link {
-  color: $color-white;
-  text-shadow: 0 4px 10px rgba($color-dark, 0.5);
-}
-
-.header--on-hero .header__logo:hover,
-.header--light .header__logo:hover {
-  color: $color-white;
-}
-
-.header--on-hero .header__nav-link:hover,
-.header--light .header__nav-link:hover {
-  color: $color-white;
-  background-color: rgba($color-white, 0.12);
-}
-
-.header--on-hero .header__nav-link--active,
-.header--light .header__nav-link--active {
-  color: $color-white;
-  background-color: rgba($color-white, 0.22);
 }
 
 // --------------------------------------------------------------------------

--- a/src/styles/_responsive.scss
+++ b/src/styles/_responsive.scss
@@ -37,12 +37,6 @@
     transition: max-height $transition-base, opacity $transition-fast, padding $transition-fast;
   }
 
-  .header--on-hero .header__nav,
-  .header--light .header__nav {
-    background-color: rgba($color-dark, 0.95);
-    border-bottom-color: rgba($color-white, 0.1);
-  }
-
   .header__nav-link {
     padding: $space-3 $space-4;
     font-size: $font-size-base;


### PR DESCRIPTION
## Resumen

Sustituye el header de degradado oscuro (heredado de la era teal y mantenido tras el rediseño «Tierra Nocturna») por un header **claro tipo crema esmerilada, sin degradado**.

## Cambios

- **`_layout.scss`** — `.header--on-hero` / `.header--light` pasan de un `linear-gradient` oscuro a `background-color` crema `#F8F2E5` al 85% (con el `backdrop-filter: blur` ya existente) y borde cálido `#E6DBC7`.
- Eliminados los overrides ya innecesarios: texto blanco de logo/nav, barra del hamburguesa blanca y el desplegable oscuro de móvil. El estilo base ya da texto oscuro con hover en terracota.
- **`_responsive.scss`** — el desplegable móvil usa el fondo claro base (antes se forzaba oscuro, que dejaría el texto ilegible).

Aplica tanto en home (sobre el hero) como en el resto de páginas.

## Verificación

- `astro build` compila sin errores.
- El CSS generado confirma el header sin `linear-gradient`: `background-color:#f8f2e5d9`, `border-bottom-color:#e6dbc7`.

https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q)_