### PR TITLE
Logo wordmark: degradado negro → terracota → ámbar en "ia"

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -91,7 +91,7 @@ const currentYear = new Date().getFullYear();
     <header class={`header${isHome ? ' header--on-hero' : ' header--light'}`}>
       <div class="container header__inner">
         <a href={url('/')} class="header__logo" aria-label="Eraldia">
-          <span class="logo-e" aria-hidden="true">e</span>raldia
+          <span class="logo-wordmark" aria-hidden="true">eraldia</span>
         </a>
 
         <input type="checkbox" id="nav-toggle" class="header__nav-toggle" aria-hidden="true">

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -167,9 +167,15 @@
   }
 }
 
-// Gradient initial "e" — doubles as the brand mark within the wordmark
-.logo-e {
-  background: linear-gradient(135deg, $color-primary-bright 0%, $color-accent-bright 100%);
+// Wordmark gradient: dark → terracotta → amber, timed so warm color lands on "ia"
+.logo-wordmark {
+  background: linear-gradient(
+    90deg,
+    $color-text       0%,
+    $color-text       58%,
+    $color-primary    72%,
+    $color-accent     100%
+  );
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;


### PR DESCRIPTION
## Resumen

El wordmark «eraldia» ahora tiene un degradado horizontal que va de negro oscuro hasta terracota→ámbar, timed para que los colores cálidos caigan exactamente sobre las letras **«ia»** — un guiño sutil a _inteligencia artificial_.

## Cambios

- **`BaseLayout.astro`** — el logo pasa de `<span class="logo-e">e</span>raldia` (solo la «e» con gradiente) a `<span class="logo-wordmark">eraldia</span>`, envolviendo la palabra entera en un único span para poder aplicar el degradado de punta a punta.
- **`_layout.scss`** — `.logo-wordmark` con `linear-gradient(90deg)`:
  - `#261F18` de 0% a 58% → texto casi negro para «eral»
  - `#B95536` (terracota) en 72% → transición cálida sobre «d»
  - `#D69A2C` (ámbar) en 100% → remate dorado en «ia»
  - `background-clip: text` para aplicarlo al texto

## Verificación

- `astro build` sin errores.
- CSS generado: `background:linear-gradient(90deg,#261f18 0% 58%,#b95536 72%,#d69a2c)`

https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q)_