### PR TITLE
Logo 1.5× más grande

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -155,7 +155,7 @@
   font-style: italic;
   font-variation-settings: 'opsz' 144;
   text-transform: lowercase;
-  font-size: 1.65rem;
+  font-size: 2.5rem;
   font-weight: 500;
   color: $color-dark;
   text-decoration: none;
@@ -287,7 +287,7 @@
   font-style: italic;
   font-variation-settings: 'opsz' 144;
   text-transform: lowercase;
-  font-size: 1.65rem;
+  font-size: 2.5rem;
   font-weight: 500;
   color: $color-white;
   margin-bottom: $space-3;


### PR DESCRIPTION
## Resumen

Aumenta el tamaño del logo de `1.65rem` a `2.5rem` (×1.5) tanto en el header como en el footer.

## Cambio

- **`_layout.scss`** — `font-size` del `.header__logo` y del logo del footer: `1.65rem` → `2.5rem`.

https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBb6XiBekPSG7ggFcTqX5Q)_