### PR TITLE
Añade diagnóstico exprés: quiz interactivo de captación de leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,40 @@ npm run preview   # previsualizar el build local
 - `src/layouts/BaseLayout.astro` — layout base con head SEO, header, footer y script reveal
 - `src/styles/` — estilos SCSS (la identidad visual vive en `src/styles/_variables.scss`)
 - `public/` — recursos estáticos (imágenes: logo, favicon, og-image, hero, services, use-cases)
-- `src/consts.ts` — constantes globales (título, tagline, email de contacto, Formspree ID, LinkedIn)
+- `src/consts.ts` — constantes globales (título, tagline, email de contacto, LinkedIn)
+- `src/pages/api/lead.ts` — endpoint que guarda los leads del formulario y del diagnóstico exprés en Cloudflare D1
+- `migrations/` — esquema SQL de la base de datos D1 de leads
 - `.github/workflows/` — CI/CD con Node 20 y Astro
+
+## Captación de leads (Cloudflare D1)
+
+El formulario de contacto y el diagnóstico exprés (`/diagnostico-express/`) envían los datos al
+endpoint `POST /api/lead`, que los inserta en una base de datos [Cloudflare D1](https://developers.cloudflare.com/d1/).
+Sin servicios de terceros: los leads quedan en tu propia base.
+
+Puesta en marcha (una sola vez):
+
+```bash
+npx wrangler d1 create eraldia-leads          # copia el database_id que devuelve
+# pégalo en wrangler.jsonc → d1_databases[0].database_id
+npx wrangler d1 migrations apply eraldia-leads            # aplica el esquema en local
+npx wrangler d1 migrations apply eraldia-leads --remote   # y en producción
+```
+
+Para consultar los leads guardados:
+
+```bash
+npx wrangler d1 execute eraldia-leads --remote --command "SELECT * FROM leads ORDER BY created_at DESC LIMIT 20"
+```
 
 ## Configuración pendiente (TODOs)
 
 En `src/consts.ts`:
-- `FORMSPREE_ID` — ID del formulario de Formspree para activar la captación de leads.
 - `CONTACT_EMAIL` — cambiar a `hola@eraldia.com` cuando el correo del dominio esté activo.
 - `LINKEDIN_URL` — URL del perfil de LinkedIn para el footer.
+
+En `wrangler.jsonc`:
+- `d1_databases[0].database_id` — pegar el ID real de la base D1 (ver sección anterior).
 
 ## Despliegue
 

--- a/docs/MODELO-DE-NEGOCIO.md
+++ b/docs/MODELO-DE-NEGOCIO.md
@@ -74,7 +74,7 @@ Reglas del embudo: responder a todo lead en <24 h laborables (la web lo promete)
 **Días 1–15 — Infraestructura.**
 - [ ] Verificar y comprar `eraldia.com` (y `.es`) en Cloudflare Registrar.
 - [ ] Publicar la web (ver `docs/PUBLICACION.md`) y activar `hola@eraldia.com` (reenvío gratuito con Cloudflare Email Routing).
-- [ ] Crear cuenta en Formspree y poner el ID en `config.toml` (`formspree_id`).
+- [ ] Crear la base de datos de leads en Cloudflare D1 y pegar su `database_id` en `wrangler.jsonc` (ver `docs/PUBLICACION.md`).
 - [ ] Alta de autónomo (si no está hecha) + gestoría. Epígrafe IAE 843.9 o similar; tarifa plana si aplica.
 - [ ] Perfil de LinkedIn actualizado con el posicionamiento de Eraldia y enlace a la web.
 - [ ] Plantillas listas: propuesta de diagnóstico, contrato simple de proyecto, factura.

--- a/docs/PUBLICACION.md
+++ b/docs/PUBLICACION.md
@@ -33,13 +33,30 @@ Cloudflare → tu dominio → **Email → Email Routing**:
 2. Para **enviar** como `hola@eraldia.com` desde Gmail: Ajustes de Gmail → Cuentas → "Enviar como" (usa los datos SMTP de Gmail con tu cuenta).
 3. Actualiza `CONTACT_EMAIL` en `src/consts.ts`.
 
-## Paso 3 — Formulario de leads (Formspree)
+## Paso 3 — Formulario de leads (Cloudflare D1)
 
-1. Cuenta gratis en [formspree.io](https://formspree.io) (50 envíos/mes de sobra para empezar).
-2. Crea un formulario apuntando a tu correo y copia su ID (p. ej. `xqkrgyzb`).
-3. Pégalo en `src/consts.ts` → `export const FORMSPREE_ID = "xqkrgyzb"`.
-4. Haz commit: el formulario de la portada se activa solo (mientras esté vacío, la web muestra un botón de correo como alternativa).
-5. En Formspree, activa la notificación por email y prueba un envío real.
+Los leads del formulario de contacto y del diagnóstico exprés se guardan en una base de datos
+**Cloudflare D1** propia (sin servicios de terceros), vía el endpoint `POST /api/lead`.
+
+1. Crea la base de datos:
+   ```bash
+   npx wrangler d1 create eraldia-leads
+   ```
+2. Copia el `database_id` que devuelve y pégalo en `wrangler.jsonc` → `d1_databases[0].database_id`.
+3. Aplica el esquema (la tabla `leads`):
+   ```bash
+   npx wrangler d1 migrations apply eraldia-leads --remote
+   ```
+4. Despliega (`npm run deploy`) y prueba un envío real desde la web.
+5. Consulta los leads cuando quieras:
+   ```bash
+   npx wrangler d1 execute eraldia-leads --remote \
+     --command "SELECT created_at, source, nombre, email FROM leads ORDER BY created_at DESC LIMIT 20"
+   ```
+
+> Aviso por email opcional: si quieres recibir un correo por cada lead, añade un envío con
+> [MailChannels/Resend](https://developers.cloudflare.com/workers/) dentro de `src/pages/api/lead.ts`
+> tras el `INSERT`. De momento los leads quedan guardados en D1 y se consultan con el comando de arriba.
 
 ## Paso 4 — Analítica (sin cookies, sin banner)
 

--- a/migrations/0001_create_leads.sql
+++ b/migrations/0001_create_leads.sql
@@ -1,0 +1,23 @@
+-- Tabla de leads de Eraldia.
+-- Recoge tanto los envíos del formulario de contacto como los del
+-- diagnóstico exprés. Los campos del diagnóstico quedan NULL en los
+-- envíos de contacto y viceversa.
+
+CREATE TABLE IF NOT EXISTS leads (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  source        TEXT NOT NULL,            -- 'contacto' | 'diagnostico'
+  nombre        TEXT,
+  email         TEXT,
+  negocio       TEXT,                     -- contacto: a qué se dedica
+  mensaje       TEXT,                     -- contacto: qué le quita tiempo
+  sector        TEXT,                     -- diagnóstico
+  proceso       TEXT,                     -- diagnóstico
+  horas         TEXT,                     -- diagnóstico
+  metodo        TEXT,                     -- diagnóstico
+  recomendacion TEXT,                     -- diagnóstico
+  user_agent    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_leads_created_at ON leads (created_at);
+CREATE INDEX IF NOT EXISTS idx_leads_source ON leads (source);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,7 +11,4 @@ export const AUTHOR = 'Gorka Alapont';
 // TODO: cambiar por hola@eraldia.com cuando el dominio y el reenvío de correo estén activos
 export const CONTACT_EMAIL = 'alapontgorka@gmail.com';
 
-// TODO: crear el formulario en https://formspree.io (gratis) y pegar aquí el ID (p. ej. "xqkrgyzb")
-export const FORMSPREE_ID = '';
-
 export const LINKEDIN_URL = '';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,26 @@
 /// <reference path="../.astro/types.d.ts" />
+
+// Subconjunto mínimo de la API de D1 que usamos en el endpoint de leads.
+// Evita depender de @cloudflare/workers-types como dependencia del proyecto.
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run<T = unknown>(): Promise<T>;
+  first<T = unknown>(colName?: string): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results: T[] }>;
+}
+
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+interface CloudflareEnv {
+  DB: D1Database;
+}
+
+declare namespace App {
+  interface Locals {
+    runtime: {
+      env: CloudflareEnv;
+    };
+  }
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,6 +37,7 @@ const isServiciosActive = currentPath.startsWith('/servicios');
 const isCasosActive = currentPath.startsWith('/casos');
 const isSobreMiActive = currentPath.startsWith('/sobre-mi');
 const isBlogActive = currentPath.startsWith('/blog');
+const isDiagnosticoActive = currentPath.startsWith('/diagnostico-express');
 
 const currentYear = new Date().getFullYear();
 ---
@@ -106,6 +107,7 @@ const currentYear = new Date().getFullYear();
           <a href={url('/casos/')} class={`header__nav-link${isCasosActive ? ' header__nav-link--active' : ''}`}>Casos de uso</a>
           <a href={url('/sobre-mi/')} class={`header__nav-link${isSobreMiActive ? ' header__nav-link--active' : ''}`}>Sobre mí</a>
           <a href={url('/blog/')} class={`header__nav-link${isBlogActive ? ' header__nav-link--active' : ''}`}>Blog</a>
+          <a href={url('/diagnostico-express/')} class={`header__nav-link${isDiagnosticoActive ? ' header__nav-link--active' : ''}`}>Diagnóstico exprés</a>
           <a href={url('/#contacto')} class="header__nav-link">Contacto</a>
         </nav>
       </div>
@@ -157,6 +159,7 @@ const currentYear = new Date().getFullYear();
               <ul class="footer__nav-list">
                 <li><a href={url('/sobre-mi/')} class="footer__nav-link">Sobre mí</a></li>
                 <li><a href={url('/casos/')} class="footer__nav-link">Casos de uso</a></li>
+                <li><a href={url('/diagnostico-express/')} class="footer__nav-link">Diagnóstico exprés</a></li>
                 <li><a href={url('/blog/')} class="footer__nav-link">Blog</a></li>
               </ul>
             </div>

--- a/src/pages/api/lead.ts
+++ b/src/pages/api/lead.ts
@@ -1,0 +1,115 @@
+import type { APIRoute } from 'astro';
+import { url } from '../../utils';
+
+// Endpoint dinámico: no se prerenderiza, se ejecuta en el Worker de Cloudflare.
+export const prerender = false;
+
+const FIELDS = [
+  'source',
+  'nombre',
+  'email',
+  'negocio',
+  'mensaje',
+  'sector',
+  'proceso',
+  'horas',
+  'metodo',
+  'recomendacion',
+] as const;
+
+type Field = (typeof FIELDS)[number];
+type LeadData = Partial<Record<Field, string>> & { _gotcha?: string };
+
+function clean(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 2000) : null;
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const contentType = request.headers.get('content-type') ?? '';
+  const wantsJson =
+    contentType.includes('application/json') ||
+    (request.headers.get('accept') ?? '').includes('application/json');
+
+  // Parseo del cuerpo (JSON desde el JS, form-urlencoded sin JS)
+  let data: LeadData = {};
+  try {
+    if (contentType.includes('application/json')) {
+      data = (await request.json()) as LeadData;
+    } else {
+      const form = await request.formData();
+      data = Object.fromEntries(form) as LeadData;
+    }
+  } catch {
+    return reply(wantsJson, 400, { ok: false, error: 'Cuerpo de la petición no válido.' });
+  }
+
+  // Honeypot anti-spam: si viene relleno, fingimos éxito y descartamos.
+  if (clean(data._gotcha)) {
+    return reply(wantsJson, 200, { ok: true });
+  }
+
+  const email = clean(data.email);
+  if (!email || !email.includes('@')) {
+    return reply(wantsJson, 400, { ok: false, error: 'Hace falta un email válido.' });
+  }
+
+  const db = locals.runtime?.env?.DB;
+
+  if (!db) {
+    // En `astro dev` no hay binding de D1; toleramos para poder probar el flujo.
+    if (import.meta.env.DEV) {
+      console.warn('[api/lead] Sin binding DB (dev): lead no guardado.', data);
+      return reply(wantsJson, 200, { ok: true, stored: false });
+    }
+    return reply(wantsJson, 500, { ok: false, error: 'Almacenamiento no disponible.' });
+  }
+
+  try {
+    await db
+      .prepare(
+        `INSERT INTO leads
+           (source, nombre, email, negocio, mensaje, sector, proceso, horas, metodo, recomendacion, user_agent)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        clean(data.source) ?? 'contacto',
+        clean(data.nombre),
+        email,
+        clean(data.negocio),
+        clean(data.mensaje),
+        clean(data.sector),
+        clean(data.proceso),
+        clean(data.horas),
+        clean(data.metodo),
+        clean(data.recomendacion),
+        clean(request.headers.get('user-agent')),
+      )
+      .run();
+  } catch (err) {
+    console.error('[api/lead] Error al guardar el lead:', err);
+    return reply(wantsJson, 500, { ok: false, error: 'No se pudo guardar el mensaje.' });
+  }
+
+  if (wantsJson) {
+    return reply(true, 200, { ok: true });
+  }
+  // Envío sin JavaScript: redirige a la página de gracias.
+  return new Response(null, {
+    status: 303,
+    headers: { Location: url('/gracias/') },
+  });
+};
+
+function reply(json: boolean, status: number, body: Record<string, unknown>): Response {
+  if (json) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  }
+  // Fallback sin JS: éxito → /gracias/, error → vuelve al contacto.
+  const location = body.ok ? url('/gracias/') : url('/#contacto');
+  return new Response(null, { status: 303, headers: { Location: location } });
+}

--- a/src/pages/diagnostico-express.astro
+++ b/src/pages/diagnostico-express.astro
@@ -1,7 +1,6 @@
 ---
 import { url, BASE } from '../utils';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { CONTACT_EMAIL, FORMSPREE_ID } from '../consts';
 
 const checkIcon =
   '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -29,7 +28,7 @@ const checkIcon =
     <!-- ============================================================ -->
     <!-- Quiz                                                          -->
     <!-- ============================================================ -->
-    <div class="diag reveal" id="diag" data-formspree={FORMSPREE_ID} data-email={CONTACT_EMAIL} data-base={BASE}>
+    <div class="diag reveal" id="diag" data-base={BASE}>
 
       <!-- Progreso -->
       <div class="diag__progress" id="diag-progress">
@@ -110,29 +109,26 @@ const checkIcon =
             concretas para tu caso. Sin newsletters: solo esta respuesta.
           </p>
 
-          {FORMSPREE_ID ? (
-            <form class="diag__form" id="diag-form" action={`https://formspree.io/f/${FORMSPREE_ID}`} method="POST">
-              <div class="diag__field">
-                <label class="diag__label" for="diag-nombre">Nombre</label>
-                <input class="diag__input" type="text" id="diag-nombre" name="nombre" required autocomplete="name">
-              </div>
-              <div class="diag__field">
-                <label class="diag__label" for="diag-email">Email</label>
-                <input class="diag__input" type="email" id="diag-email" name="email" required autocomplete="email">
-              </div>
-              <input type="hidden" name="sector" id="diag-h-sector">
-              <input type="hidden" name="proceso" id="diag-h-proceso">
-              <input type="hidden" name="horas" id="diag-h-horas">
-              <input type="hidden" name="metodo" id="diag-h-metodo">
-              <input type="hidden" name="recomendacion" id="diag-h-recom">
-              <input type="hidden" name="_subject" value="Diagnóstico exprés — nuevo lead">
-              <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
-              <button type="submit" class="btn btn--outline btn--full">Enviarme el mini-plan</button>
-              <p class="diag__note">Al enviar aceptas que use estos datos solo para responderte.</p>
-            </form>
-          ) : (
-            <a class="btn btn--outline btn--full" id="diag-mailto" href={`mailto:${CONTACT_EMAIL}`}>Enviarme el mini-plan por email</a>
-          )}
+          <form class="diag__form" id="diag-form" action={url('/api/lead')} method="POST">
+            <input type="hidden" name="source" value="diagnostico">
+            <div class="diag__field">
+              <label class="diag__label" for="diag-nombre">Nombre</label>
+              <input class="diag__input" type="text" id="diag-nombre" name="nombre" required autocomplete="name">
+            </div>
+            <div class="diag__field">
+              <label class="diag__label" for="diag-email">Email</label>
+              <input class="diag__input" type="email" id="diag-email" name="email" required autocomplete="email">
+            </div>
+            <input type="hidden" name="sector" id="diag-h-sector">
+            <input type="hidden" name="proceso" id="diag-h-proceso">
+            <input type="hidden" name="horas" id="diag-h-horas">
+            <input type="hidden" name="metodo" id="diag-h-metodo">
+            <input type="hidden" name="recomendacion" id="diag-h-recom">
+            <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
+            <button type="submit" class="btn btn--outline btn--full">Enviarme el mini-plan</button>
+            <p class="diag__note">Al enviar aceptas que use estos datos solo para responderte.</p>
+            <p class="contact-form__feedback" id="diag-feedback" role="status" aria-live="polite" hidden></p>
+          </form>
         </div>
       </div>
 
@@ -269,32 +265,12 @@ const checkIcon =
     cta.href = prefix(ctaHref);
     cta.textContent = ctaText;
 
-    var resumen = [
-      'Sector: ' + (labels.sector || '—'),
-      'Proceso: ' + (labels.proceso || '—'),
-      'Tiempo/semana: ' + (labels.horas || '—'),
-      'Situación actual: ' + (labels.metodo || '—'),
-      'Recomendación: ' + level + ' — ' + action
-    ].join('\n');
-
-    // Formspree (campos ocultos) o mailto, según configuración
-    var hSector = document.getElementById('diag-h-sector');
-    if (hSector) {
-      hSector.value = labels.sector || '';
-      document.getElementById('diag-h-proceso').value = labels.proceso || '';
-      document.getElementById('diag-h-horas').value = labels.horas || '';
-      document.getElementById('diag-h-metodo').value = labels.metodo || '';
-      document.getElementById('diag-h-recom').value = level + ' — ' + action;
-    }
-
-    var mailto = document.getElementById('diag-mailto');
-    if (mailto) {
-      var email = root.getAttribute('data-email');
-      var subject = 'Diagnóstico exprés — ' + (labels.sector || 'mi negocio');
-      var bodyTxt = 'Hola Gorka,\n\nHe hecho el diagnóstico exprés y estos son mis datos:\n\n' +
-        resumen + '\n\nMe gustaría recibir el mini-plan ampliado.\n\nGracias.';
-      mailto.href = 'mailto:' + email + '?subject=' + encodeURIComponent(subject) + '&body=' + encodeURIComponent(bodyTxt);
-    }
+    // Campos ocultos que viajan a /api/lead junto al nombre y el email.
+    document.getElementById('diag-h-sector').value = labels.sector || '';
+    document.getElementById('diag-h-proceso').value = labels.proceso || '';
+    document.getElementById('diag-h-horas').value = labels.horas || '';
+    document.getElementById('diag-h-metodo').value = labels.metodo || '';
+    document.getElementById('diag-h-recom').value = level + ' — ' + action;
   }
 
   // Prefija rutas internas con la base del despliegue (GitHub Pages usa subcarpeta)
@@ -302,6 +278,42 @@ const checkIcon =
     var base = (root.getAttribute('data-base') || '').replace(/\/$/, '');
     if (path.charAt(0) !== '/') return path;
     return base + path;
+  }
+
+  // Envío del lead a /api/lead (D1) con mejora progresiva.
+  var form = document.getElementById('diag-form');
+  if (form) {
+    var feedback = document.getElementById('diag-feedback');
+    var submitBtn = form.querySelector('button[type="submit"]');
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Enviando…'; }
+      if (feedback) { feedback.hidden = true; feedback.className = 'contact-form__feedback'; }
+      fetch(form.action, {
+        method: 'POST',
+        headers: { 'Accept': 'application/json' },
+        body: new FormData(form)
+      })
+        .then(function (r) { return r.json().catch(function () { return { ok: r.ok }; }); })
+        .then(function (data) {
+          if (!data || !data.ok) throw new Error('Error');
+          form.reset();
+          if (feedback) {
+            feedback.textContent = '¡Hecho! Te llega el mini-plan a tu correo en menos de 24 horas laborables.';
+            feedback.classList.add('is-success');
+            feedback.hidden = false;
+          }
+          if (submitBtn) submitBtn.textContent = 'Enviado ✓';
+        })
+        .catch(function () {
+          if (feedback) {
+            feedback.textContent = 'No se pudo enviar. Inténtalo de nuevo en un momento.';
+            feedback.classList.add('is-error');
+            feedback.hidden = false;
+          }
+          if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Enviarme el mini-plan'; }
+        });
+    });
   }
 
   show(0);

--- a/src/pages/diagnostico-express.astro
+++ b/src/pages/diagnostico-express.astro
@@ -1,0 +1,311 @@
+---
+import { url, BASE } from '../utils';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { CONTACT_EMAIL, FORMSPREE_ID } from '../consts';
+
+const checkIcon =
+  '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
+---
+
+<BaseLayout
+  title="Diagnóstico exprés"
+  description="Responde 4 preguntas y descubre en un minuto qué proceso de tu pyme conviene automatizar primero y por dónde empezar. Gratis y sin registro."
+>
+
+<!-- ================================================================ -->
+<!-- Cabecera                                                          -->
+<!-- ================================================================ -->
+<section class="section section--alt">
+  <div class="container container--narrow">
+    <div class="section__header">
+      <span class="hero__badge">Gratis · 1 minuto · sin registro</span>
+      <h1 class="section__title">Diagnóstico exprés de automatización</h1>
+      <p class="section__subtitle">
+        Cuatro preguntas rápidas sobre tu negocio y te digo qué proceso conviene automatizar
+        primero y cuál es el siguiente paso más sensato. Sin compromiso y sin jerga.
+      </p>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Quiz                                                          -->
+    <!-- ============================================================ -->
+    <div class="diag reveal" id="diag" data-formspree={FORMSPREE_ID} data-email={CONTACT_EMAIL} data-base={BASE}>
+
+      <!-- Progreso -->
+      <div class="diag__progress" id="diag-progress">
+        <div class="diag__progress-track">
+          <span class="diag__progress-bar" id="diag-bar"></span>
+        </div>
+        <span class="diag__progress-label" id="diag-progress-label">Paso 1 de 4</span>
+      </div>
+
+      <!-- Paso 1 — Sector -->
+      <div class="diag__step is-active" data-step="0">
+        <span class="diag__eyebrow">Tu negocio</span>
+        <h2 class="diag__question">¿A qué se dedica tu pyme?</h2>
+        <div class="diag__options" data-key="sector">
+          <button type="button" class="diag__option" data-value="gestoria" data-label="Gestoría o asesoría"><span class="diag__option-mark" set:html={checkIcon}></span>Gestoría o asesoría</button>
+          <button type="button" class="diag__option" data-value="clinica" data-label="Clínica (dental, fisio, veterinaria)"><span class="diag__option-mark" set:html={checkIcon}></span>Clínica (dental, fisio, veterinaria)</button>
+          <button type="button" class="diag__option" data-value="hosteleria" data-label="Hostelería o gimnasio"><span class="diag__option-mark" set:html={checkIcon}></span>Hostelería, restaurante o gimnasio</button>
+          <button type="button" class="diag__option" data-value="inmo" data-label="Inmobiliaria o despacho"><span class="diag__option-mark" set:html={checkIcon}></span>Inmobiliaria o despacho profesional</button>
+          <button type="button" class="diag__option" data-value="otro" data-label="Otro sector"><span class="diag__option-mark" set:html={checkIcon}></span>Otro tipo de negocio</button>
+        </div>
+      </div>
+
+      <!-- Paso 2 — Proceso -->
+      <div class="diag__step" data-step="1">
+        <span class="diag__eyebrow">El dolor</span>
+        <h2 class="diag__question">¿Qué tarea os come más tiempo cada semana?</h2>
+        <div class="diag__options" data-key="proceso">
+          <button type="button" class="diag__option" data-value="atencion" data-label="Responder siempre las mismas preguntas"><span class="diag__option-mark" set:html={checkIcon}></span>Responder siempre las mismas preguntas (teléfono, email, WhatsApp)</button>
+          <button type="button" class="diag__option" data-value="citas" data-label="Gestionar citas o reservas"><span class="diag__option-mark" set:html={checkIcon}></span>Gestionar citas o reservas (y las ausencias)</button>
+          <button type="button" class="diag__option" data-value="presupuestos" data-label="Hacer presupuestos o pasar facturas"><span class="diag__option-mark" set:html={checkIcon}></span>Hacer presupuestos o pasar facturas a mano</button>
+          <button type="button" class="diag__option" data-value="informes" data-label="Preparar informes o mover datos"><span class="diag__option-mark" set:html={checkIcon}></span>Preparar informes o mover datos entre programas</button>
+          <button type="button" class="diag__option" data-value="captacion" data-label="Captar y seguir a clientes nuevos"><span class="diag__option-mark" set:html={checkIcon}></span>Captar y dar seguimiento a clientes nuevos</button>
+        </div>
+      </div>
+
+      <!-- Paso 3 — Horas -->
+      <div class="diag__step" data-step="2">
+        <span class="diag__eyebrow">El volumen</span>
+        <h2 class="diag__question">¿Cuánto tiempo le dedicáis a la semana?</h2>
+        <div class="diag__options" data-key="horas">
+          <button type="button" class="diag__option" data-value="1" data-label="Menos de 2 horas"><span class="diag__option-mark" set:html={checkIcon}></span>Menos de 2 horas</button>
+          <button type="button" class="diag__option" data-value="3" data-label="Entre 2 y 5 horas"><span class="diag__option-mark" set:html={checkIcon}></span>Entre 2 y 5 horas</button>
+          <button type="button" class="diag__option" data-value="7" data-label="Entre 5 y 10 horas"><span class="diag__option-mark" set:html={checkIcon}></span>Entre 5 y 10 horas</button>
+          <button type="button" class="diag__option" data-value="12" data-label="Más de 10 horas"><span class="diag__option-mark" set:html={checkIcon}></span>Más de 10 horas</button>
+        </div>
+      </div>
+
+      <!-- Paso 4 — Método actual -->
+      <div class="diag__step" data-step="3">
+        <span class="diag__eyebrow">El punto de partida</span>
+        <h2 class="diag__question">¿Cómo lo hacéis ahora mismo?</h2>
+        <div class="diag__options" data-key="metodo">
+          <button type="button" class="diag__option" data-value="manual" data-label="A mano, sin herramientas"><span class="diag__option-mark" set:html={checkIcon}></span>A mano, sin ninguna herramienta</button>
+          <button type="button" class="diag__option" data-value="sheets" data-label="Con hojas de cálculo"><span class="diag__option-mark" set:html={checkIcon}></span>Con hojas de cálculo (Excel, Sheets)</button>
+          <button type="button" class="diag__option" data-value="software" data-label="Con un programa, metiendo datos a mano"><span class="diag__option-mark" set:html={checkIcon}></span>Con un programa, pero metiendo datos a mano</button>
+          <button type="button" class="diag__option" data-value="auto" data-label="Ya algo automatizado, quiero mejorarlo"><span class="diag__option-mark" set:html={checkIcon}></span>Ya tengo algo automatizado y quiero mejorarlo</button>
+        </div>
+      </div>
+
+      <!-- Paso 5 — Resultado -->
+      <div class="diag__step" data-step="4">
+        <span class="diag__result-level" id="diag-level"></span>
+        <h2 class="diag__result-title" id="diag-result-title"></h2>
+        <p class="diag__result-body" id="diag-result-body"></p>
+
+        <div class="diag__result-card">
+          <p class="diag__result-card-label">Por dónde empezaría</p>
+          <p class="diag__result-card-text" id="diag-result-action"></p>
+        </div>
+
+        <a class="btn btn--primary btn--lg btn--full" id="diag-cta" href={url('/#contacto')}>Reservar mi llamada gratuita</a>
+
+        <!-- Captura de lead -->
+        <div class="diag__capture">
+          <h3 class="diag__capture-title">¿Te envío el mini-plan por email?</h3>
+          <p class="diag__capture-desc">
+            Te mando un correo con esta recomendación ampliada y las 2-3 automatizaciones
+            concretas para tu caso. Sin newsletters: solo esta respuesta.
+          </p>
+
+          {FORMSPREE_ID ? (
+            <form class="diag__form" id="diag-form" action={`https://formspree.io/f/${FORMSPREE_ID}`} method="POST">
+              <div class="diag__field">
+                <label class="diag__label" for="diag-nombre">Nombre</label>
+                <input class="diag__input" type="text" id="diag-nombre" name="nombre" required autocomplete="name">
+              </div>
+              <div class="diag__field">
+                <label class="diag__label" for="diag-email">Email</label>
+                <input class="diag__input" type="email" id="diag-email" name="email" required autocomplete="email">
+              </div>
+              <input type="hidden" name="sector" id="diag-h-sector">
+              <input type="hidden" name="proceso" id="diag-h-proceso">
+              <input type="hidden" name="horas" id="diag-h-horas">
+              <input type="hidden" name="metodo" id="diag-h-metodo">
+              <input type="hidden" name="recomendacion" id="diag-h-recom">
+              <input type="hidden" name="_subject" value="Diagnóstico exprés — nuevo lead">
+              <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
+              <button type="submit" class="btn btn--outline btn--full">Enviarme el mini-plan</button>
+              <p class="diag__note">Al enviar aceptas que use estos datos solo para responderte.</p>
+            </form>
+          ) : (
+            <a class="btn btn--outline btn--full" id="diag-mailto" href={`mailto:${CONTACT_EMAIL}`}>Enviarme el mini-plan por email</a>
+          )}
+        </div>
+      </div>
+
+      <!-- Navegación -->
+      <div class="diag__nav" id="diag-nav">
+        <button type="button" class="diag__back" id="diag-back" hidden>&larr; Atrás</button>
+        <span></span>
+      </div>
+
+      <noscript>
+        <p class="diag__noscript">
+          Esta herramienta necesita JavaScript. Si lo tienes desactivado,
+          <a href={url('/#contacto')}>escríbeme dos líneas sobre tu negocio</a> y te respondo en menos de 24 horas.
+        </p>
+      </noscript>
+
+    </div>
+  </div>
+</section>
+
+<script is:inline>
+(function () {
+  var root = document.getElementById('diag');
+  if (!root) return;
+
+  var TOTAL = 4;
+  var answers = {};
+  var labels = {};
+  var current = 0;
+
+  var steps = Array.prototype.slice.call(root.querySelectorAll('.diag__step'));
+  var bar = document.getElementById('diag-bar');
+  var progress = document.getElementById('diag-progress');
+  var progressLabel = document.getElementById('diag-progress-label');
+  var back = document.getElementById('diag-back');
+
+  function show(index) {
+    current = index;
+    steps.forEach(function (s) {
+      s.classList.toggle('is-active', Number(s.getAttribute('data-step')) === index);
+    });
+    var isResult = index >= TOTAL;
+    progress.style.display = isResult ? 'none' : '';
+    if (!isResult) {
+      bar.style.width = ((index + 1) / TOTAL) * 100 + '%';
+      progressLabel.textContent = 'Paso ' + (index + 1) + ' de ' + TOTAL;
+    }
+    back.hidden = index === 0 || isResult;
+    var focusable = steps[index] && steps[index].querySelector('.diag__option, input, a, button');
+    if (focusable && index > 0) { try { focusable.focus({ preventScroll: true }); } catch (e) {} }
+  }
+
+  // Selección de opción
+  root.querySelectorAll('.diag__options').forEach(function (group) {
+    var key = group.getAttribute('data-key');
+    group.querySelectorAll('.diag__option').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        group.querySelectorAll('.diag__option').forEach(function (b) { b.classList.remove('is-selected'); });
+        btn.classList.add('is-selected');
+        answers[key] = btn.getAttribute('data-value');
+        labels[key] = btn.getAttribute('data-label');
+        setTimeout(function () {
+          if (current + 1 >= TOTAL) { buildResult(); show(TOTAL); }
+          else { show(current + 1); }
+        }, 220);
+      });
+    });
+  });
+
+  back.addEventListener('click', function () { if (current > 0) show(current - 1); });
+
+  // --- Lógica de recomendación ------------------------------------------
+  var PROCESOS = {
+    atencion:     { nombre: 'la atención a preguntas repetidas', accion: 'un asistente que responde las preguntas frecuentes por WhatsApp, web o email a cualquier hora, y te pasa solo lo que necesita tu intervención.' },
+    citas:        { nombre: 'la gestión de citas y reservas', accion: 'recordatorios automáticos y gestión de citas/reservas que reducen las ausencias y los huecos sin llamadas manuales.' },
+    presupuestos: { nombre: 'los presupuestos y la facturación', accion: 'generación automática de presupuestos y facturas a partir de tus datos, lista para enviar en minutos en vez de horas.' },
+    informes:     { nombre: 'los informes y el traspaso de datos', accion: 'un flujo que mueve los datos entre tus programas y arma los informes solo, sin copiar y pegar.' },
+    captacion:    { nombre: 'la captación y el seguimiento de clientes', accion: 'un seguimiento automático de cada contacto nuevo (CRM ligero) para que ningún lead se enfríe ni se pierda.' }
+  };
+
+  var SECTORES = {
+    gestoria: 'gestoría o asesoría', clinica: 'clínica', hosteleria: 'negocio de hostelería o fitness',
+    inmo: 'inmobiliaria o despacho', otro: 'negocio'
+  };
+
+  var METODO_PESO = { manual: 1.0, sheets: 0.9, software: 0.8, auto: 0.5 };
+
+  function buildResult() {
+    var horas = Number(answers.horas) || 1;
+    var peso = METODO_PESO[answers.metodo] != null ? METODO_PESO[answers.metodo] : 0.8;
+    var score = horas * peso;
+    var proc = PROCESOS[answers.proceso] || PROCESOS.atencion;
+    var sector = SECTORES[answers.sector] || 'negocio';
+
+    var level, levelClass, title, body, action, ctaHref, ctaText;
+    var serviciosBase = '/servicios/';
+
+    if (score >= 6) {
+      level = 'Potencial alto';
+      levelClass = 'alto';
+      title = 'Tienes un caso claro para automatizar.';
+      body = 'Dedicáis bastante tiempo a ' + proc.nombre + ' y todavía de forma manual. En una ' +
+        sector + ' eso es justo el tipo de proceso repetible que sale rentable automatizar pronto: el ahorro de horas se nota desde el primer mes.';
+      action = 'Una automatización a medida: ' + proc.accion;
+      ctaHref = serviciosBase + 'automatizacion/';
+      ctaText = 'Ver cómo sería la automatización';
+    } else if (score >= 3) {
+      level = 'Potencial medio';
+      levelClass = 'medio';
+      title = 'Hay margen, y conviene medirlo bien antes de invertir.';
+      body = 'En tu ' + sector + ' se va tiempo en ' + proc.nombre + ', pero merece la pena cuantificar el ahorro real ' +
+        'antes de construir nada. Para eso está el diagnóstico: dos semanas para priorizar qué automatizar y con qué retorno.';
+      action = 'Un diagnóstico de IA que mida el ahorro de automatizar ' + proc.nombre + ' y lo priorice frente a otras tareas.';
+      ctaHref = serviciosBase + 'diagnostico-ia/';
+      ctaText = 'Ver el diagnóstico de IA';
+    } else {
+      level = 'Para explorar';
+      levelClass = 'explorar';
+      title = 'Aún no es tu mayor urgencia, pero hay por dónde empezar.';
+      body = 'De momento ' + proc.nombre + ' no os quita tantas horas, así que no tiene sentido un proyecto grande. ' +
+        'Lo más rentable es una llamada de 30 minutos para detectar el proceso que de verdad duela en tu ' + sector + '.';
+      action = 'Una llamada gratuita de 30 minutos para localizar el proceso con más potencial antes de invertir nada.';
+      ctaHref = '/#contacto';
+      ctaText = 'Reservar mi llamada gratuita';
+    }
+
+    document.getElementById('diag-level').textContent = level;
+    document.getElementById('diag-level').className = 'diag__result-level diag__result-level--' + levelClass;
+    document.getElementById('diag-result-title').textContent = title;
+    document.getElementById('diag-result-body').textContent = body;
+    document.getElementById('diag-result-action').textContent = action;
+
+    var cta = document.getElementById('diag-cta');
+    cta.href = prefix(ctaHref);
+    cta.textContent = ctaText;
+
+    var resumen = [
+      'Sector: ' + (labels.sector || '—'),
+      'Proceso: ' + (labels.proceso || '—'),
+      'Tiempo/semana: ' + (labels.horas || '—'),
+      'Situación actual: ' + (labels.metodo || '—'),
+      'Recomendación: ' + level + ' — ' + action
+    ].join('\n');
+
+    // Formspree (campos ocultos) o mailto, según configuración
+    var hSector = document.getElementById('diag-h-sector');
+    if (hSector) {
+      hSector.value = labels.sector || '';
+      document.getElementById('diag-h-proceso').value = labels.proceso || '';
+      document.getElementById('diag-h-horas').value = labels.horas || '';
+      document.getElementById('diag-h-metodo').value = labels.metodo || '';
+      document.getElementById('diag-h-recom').value = level + ' — ' + action;
+    }
+
+    var mailto = document.getElementById('diag-mailto');
+    if (mailto) {
+      var email = root.getAttribute('data-email');
+      var subject = 'Diagnóstico exprés — ' + (labels.sector || 'mi negocio');
+      var bodyTxt = 'Hola Gorka,\n\nHe hecho el diagnóstico exprés y estos son mis datos:\n\n' +
+        resumen + '\n\nMe gustaría recibir el mini-plan ampliado.\n\nGracias.';
+      mailto.href = 'mailto:' + email + '?subject=' + encodeURIComponent(subject) + '&body=' + encodeURIComponent(bodyTxt);
+    }
+  }
+
+  // Prefija rutas internas con la base del despliegue (GitHub Pages usa subcarpeta)
+  function prefix(path) {
+    var base = (root.getAttribute('data-base') || '').replace(/\/$/, '');
+    if (path.charAt(0) !== '/') return path;
+    return base + path;
+  }
+
+  show(0);
+})();
+</script>
+
+</BaseLayout>

--- a/src/pages/gracias.astro
+++ b/src/pages/gracias.astro
@@ -1,0 +1,29 @@
+---
+import { url } from '../utils';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Gracias"
+  description="Hemos recibido tu mensaje. Te respondo en menos de 24 horas laborables."
+>
+
+<section class="section section--alt">
+  <div class="container container--narrow">
+    <div class="cta cta--inline cta--dark reveal" aria-label="Mensaje recibido">
+      <div class="cta__inner">
+        <h1 class="cta__title">¡Recibido! Gracias por escribir.</h1>
+        <p class="cta__desc">
+          Tengo tus datos y te respondo en menos de 24 horas laborables con los siguientes pasos.
+          Mientras tanto, puedes echar un vistazo a casos de uso por sector o a algún artículo del blog.
+        </p>
+        <div class="hero__actions">
+          <a href={url('/casos/')} class="btn btn--primary btn--lg">Ver casos de uso</a>
+          <a href={url('/blog/')} class="btn btn--outline-white btn--lg">Leer el blog</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { url } from '../utils';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts';
 ---
 
 <BaseLayout
@@ -30,8 +30,11 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } fr
     </p>
     <div class="hero__actions">
       <a href="#contacto" class="btn btn--primary btn--lg">Pide tu diagnóstico gratuito</a>
-      <a href={url('/servicios/')} class="btn btn--outline btn--lg">Ver servicios</a>
+      <a href={url('/diagnostico-express/')} class="btn btn--outline btn--lg">Diagnóstico exprés (1 min)</a>
     </div>
+    <p class="hero__actions-note">
+      ¿Prefieres una pista al instante? Responde 4 preguntas y te digo qué automatizar primero. O <a href={url('/servicios/')}>mira los servicios</a>.
+    </p>
     <div class="hero__stats">
       <div class="hero__stat">
         <span class="hero__stat-number">30</span>
@@ -192,43 +195,76 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } fr
       </p>
     </div>
 
-    {FORMSPREE_ID ? (
-      <form class="contact-form reveal" action={`https://formspree.io/f/${FORMSPREE_ID}`} method="POST">
-        <div class="contact-form__row">
-          <div class="contact-form__field">
-            <label for="cf-nombre" class="contact-form__label">Nombre</label>
-            <input type="text" id="cf-nombre" name="nombre" class="contact-form__input" required autocomplete="name">
-          </div>
-          <div class="contact-form__field">
-            <label for="cf-email" class="contact-form__label">Email</label>
-            <input type="email" id="cf-email" name="email" class="contact-form__input" required autocomplete="email">
-          </div>
+    <form class="contact-form reveal" id="contact-form" action={url('/api/lead')} method="POST" data-email={CONTACT_EMAIL}>
+      <input type="hidden" name="source" value="contacto">
+      <div class="contact-form__row">
+        <div class="contact-form__field">
+          <label for="cf-nombre" class="contact-form__label">Nombre</label>
+          <input type="text" id="cf-nombre" name="nombre" class="contact-form__input" required autocomplete="name">
         </div>
         <div class="contact-form__field">
-          <label for="cf-negocio" class="contact-form__label">¿A qué se dedica tu negocio?</label>
-          <input type="text" id="cf-negocio" name="negocio" class="contact-form__input" placeholder="Ej.: clínica dental, gestoría, tienda online...">
-        </div>
-        <div class="contact-form__field">
-          <label for="cf-mensaje" class="contact-form__label">¿Qué proceso te quita más tiempo?</label>
-          <textarea id="cf-mensaje" name="mensaje" class="contact-form__textarea" rows="4" required placeholder="Ej.: contestar siempre las mismas preguntas por WhatsApp, hacer presupuestos, pasar facturas a mano..."></textarea>
-        </div>
-        {/* Honeypot anti-spam */}
-        <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
-        <button type="submit" class="btn btn--primary btn--lg contact-form__submit">Enviar y reservar mi llamada gratuita</button>
-        <p class="contact-form__note">Al enviar aceptas que use estos datos solo para responderte. Nada de newsletters sorpresa.</p>
-      </form>
-    ) : (
-      <div class="cta cta--inline cta--dark reveal" aria-label="Contacto por correo">
-        <div class="cta__inner">
-          <h2 class="cta__title">Escríbeme directamente</h2>
-          <p class="cta__desc">
-            Mándame un correo con dos líneas sobre tu negocio y el proceso que más tiempo te quita. Te respondo en menos de 24 horas laborables.
-          </p>
-          <a href={`mailto:${CONTACT_EMAIL}?subject=Llamada%20gratuita%20de%2030%20minutos`} class="btn btn--primary btn--lg">Enviar correo</a>
+          <label for="cf-email" class="contact-form__label">Email</label>
+          <input type="email" id="cf-email" name="email" class="contact-form__input" required autocomplete="email">
         </div>
       </div>
-    )}
+      <div class="contact-form__field">
+        <label for="cf-negocio" class="contact-form__label">¿A qué se dedica tu negocio?</label>
+        <input type="text" id="cf-negocio" name="negocio" class="contact-form__input" placeholder="Ej.: clínica dental, gestoría, tienda online...">
+      </div>
+      <div class="contact-form__field">
+        <label for="cf-mensaje" class="contact-form__label">¿Qué proceso te quita más tiempo?</label>
+        <textarea id="cf-mensaje" name="mensaje" class="contact-form__textarea" rows="4" required placeholder="Ej.: contestar siempre las mismas preguntas por WhatsApp, hacer presupuestos, pasar facturas a mano..."></textarea>
+      </div>
+      {/* Honeypot anti-spam */}
+      <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
+      <button type="submit" class="btn btn--primary btn--lg contact-form__submit">Enviar y reservar mi llamada gratuita</button>
+      <p class="contact-form__note">Al enviar aceptas que use estos datos solo para responderte. Nada de newsletters sorpresa.</p>
+      <p class="contact-form__feedback" id="contact-feedback" role="status" aria-live="polite" hidden></p>
+    </form>
   </div>
 </section>
+
+<script is:inline>
+(function () {
+  var form = document.getElementById('contact-form');
+  if (!form) return;
+  var feedback = document.getElementById('contact-feedback');
+  var btn = form.querySelector('button[type="submit"]');
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    if (btn) { btn.disabled = true; btn.textContent = 'Enviando…'; }
+    if (feedback) { feedback.hidden = true; feedback.className = 'contact-form__feedback'; }
+
+    fetch(form.action, {
+      method: 'POST',
+      headers: { 'Accept': 'application/json' },
+      body: new FormData(form)
+    })
+      .then(function (r) { return r.json().catch(function () { return { ok: r.ok }; }); })
+      .then(function (data) {
+        if (data && data.ok) {
+          form.reset();
+          if (feedback) {
+            feedback.textContent = '¡Recibido! Te respondo en menos de 24 horas laborables.';
+            feedback.classList.add('is-success');
+            feedback.hidden = false;
+          }
+          if (btn) btn.textContent = 'Enviado ✓';
+        } else {
+          throw new Error((data && data.error) || 'Error');
+        }
+      })
+      .catch(function () {
+        if (feedback) {
+          feedback.textContent = 'No se pudo enviar. Inténtalo de nuevo o escríbeme a ' + (form.getAttribute('data-email') || '') + '.';
+          feedback.classList.add('is-error');
+          feedback.hidden = false;
+        }
+        if (btn) { btn.disabled = false; btn.textContent = 'Enviar y reservar mi llamada gratuita'; }
+      });
+  });
+})();
+</script>
 
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -174,6 +174,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL, FORMSPREE_ID } fr
           <li>Una opinión honesta: si la IA no te va a ayudar, te lo digo</li>
         </ul>
         <a href="#contacto" class="btn btn--outline-white btn--lg">Reservar mi llamada</a>
+        <a href={url('/diagnostico-express/')} class="btn btn--outline-white btn--lg">Haz el diagnóstico exprés (1 min)</a>
       </div>
     </div>
   </div>

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -320,6 +320,21 @@
   justify-content: center;
 }
 
+.hero__actions-note {
+  margin: $space-4 auto 0;
+  max-width: 560px;
+  font-size: $font-size-sm;
+  color: rgba($color-white, 0.72);
+
+  a {
+    color: $color-white;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover { color: $color-accent-bright; }
+  }
+}
+
 // Hero stats block
 .hero__stats {
   display: flex;
@@ -1066,5 +1081,24 @@
     color: $color-muted;
     text-align: center;
     margin: $space-3 0 0;
+  }
+
+  &__feedback {
+    margin: $space-4 0 0;
+    padding: $space-3 $space-4;
+    border-radius: $border-radius;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-medium;
+    text-align: center;
+
+    &.is-success {
+      background: rgba($color-sage, 0.18);
+      color: darken($color-sage, 26%);
+    }
+
+    &.is-error {
+      background: rgba($color-primary, 0.1);
+      color: $color-primary-dark;
+    }
   }
 }

--- a/src/styles/_diagnostico.scss
+++ b/src/styles/_diagnostico.scss
@@ -1,0 +1,298 @@
+// ==========================================================================
+// Diagnóstico exprés — quiz interactivo de captación
+// ==========================================================================
+// Herramienta de 4 preguntas que devuelve una recomendación orientativa y
+// alimenta el embudo (Formspree o mailto). Markup estático, JS progresivo.
+
+.diag {
+  max-width: 720px;
+  margin: 0 auto;
+  background: $color-white;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-xl;
+  padding: $space-7;
+  box-shadow: $shadow-md;
+
+  @media (max-width: $bp-sm) {
+    padding: $space-5;
+  }
+
+  // --- Barra de progreso ---------------------------------------------------
+  &__progress {
+    display: flex;
+    align-items: center;
+    gap: $space-3;
+    margin-bottom: $space-6;
+  }
+
+  &__progress-track {
+    flex: 1;
+    height: 6px;
+    background: $color-bg-alt;
+    border-radius: $border-radius-full;
+    overflow: hidden;
+  }
+
+  &__progress-bar {
+    display: block;
+    height: 100%;
+    width: 25%;
+    background: linear-gradient(90deg, $color-primary, $color-accent);
+    border-radius: $border-radius-full;
+    transition: width $transition-base;
+  }
+
+  &__progress-label {
+    font-family: $font-code;
+    font-size: $font-size-xs;
+    color: $color-muted;
+    white-space: nowrap;
+  }
+
+  // --- Pasos ---------------------------------------------------------------
+  &__step {
+    display: none;
+
+    &.is-active {
+      display: block;
+      animation: diag-fade 300ms ease both;
+    }
+  }
+
+  &__eyebrow {
+    display: block;
+    font-family: $font-code;
+    font-size: $font-size-xs;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: $color-primary;
+    margin-bottom: $space-2;
+  }
+
+  &__question {
+    font-family: $font-heading;
+    font-style: italic;
+    font-size: $font-size-xl;
+    line-height: $line-height-tight;
+    color: $color-dark;
+    margin: 0 0 $space-5;
+  }
+
+  // --- Opciones ------------------------------------------------------------
+  &__options {
+    display: grid;
+    gap: $space-3;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    gap: $space-3;
+    width: 100%;
+    text-align: left;
+    font-family: $font-body;
+    font-size: $font-size-base;
+    font-weight: $font-weight-medium;
+    color: $color-text;
+    background: $color-light;
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+    padding: $space-4;
+    cursor: pointer;
+    transition: border-color $transition-fast, background $transition-fast, transform $transition-fast;
+
+    &:hover,
+    &:focus-visible {
+      border-color: $color-primary;
+      background: $color-white;
+      outline: none;
+      transform: translateY(-1px);
+    }
+
+    &.is-selected {
+      border-color: $color-primary;
+      background: rgba($color-primary, 0.06);
+      box-shadow: 0 0 0 3px rgba($color-primary, 0.12);
+    }
+  }
+
+  &__option-mark {
+    flex: 0 0 auto;
+    width: 22px;
+    height: 22px;
+    border-radius: $border-radius-full;
+    border: 2px solid $color-border;
+    display: grid;
+    place-items: center;
+    color: $color-white;
+    transition: border-color $transition-fast, background $transition-fast;
+
+    .diag__option.is-selected & {
+      border-color: $color-primary;
+      background: $color-primary;
+    }
+
+    svg {
+      opacity: 0;
+      transition: opacity $transition-fast;
+
+      .diag__option.is-selected & {
+        opacity: 1;
+      }
+    }
+  }
+
+  // --- Navegación ----------------------------------------------------------
+  &__nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: $space-6;
+  }
+
+  &__back {
+    background: none;
+    border: none;
+    font-family: $font-body;
+    font-size: $font-size-sm;
+    font-weight: $font-weight-medium;
+    color: $color-muted;
+    cursor: pointer;
+    padding: $space-2 0;
+
+    &:hover { color: $color-primary; }
+    &[hidden] { visibility: hidden; }
+  }
+
+  // --- Resultado -----------------------------------------------------------
+  &__result-level {
+    display: inline-flex;
+    align-items: center;
+    gap: $space-2;
+    font-family: $font-code;
+    font-size: $font-size-xs;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: $font-weight-medium;
+    padding: $space-2 $space-3;
+    border-radius: $border-radius-full;
+    margin-bottom: $space-4;
+
+    &--alto   { background: rgba($color-primary, 0.1); color: $color-primary-dark; }
+    &--medio  { background: rgba($color-accent, 0.16); color: $color-accent-dark; }
+    &--explorar { background: rgba($color-sage, 0.18); color: darken($color-sage, 22%); }
+  }
+
+  &__result-title {
+    font-family: $font-heading;
+    font-style: italic;
+    font-size: 1.5rem;
+    line-height: $line-height-tight;
+    color: $color-dark;
+    margin: 0 0 $space-4;
+  }
+
+  &__result-body {
+    font-size: $font-size-base;
+    color: $color-text-light;
+    line-height: $line-height-base;
+    margin: 0 0 $space-5;
+  }
+
+  &__result-card {
+    background: $color-light;
+    border: 1px solid $color-border;
+    border-left: 3px solid $color-primary;
+    border-radius: $border-radius;
+    padding: $space-4 $space-5;
+    margin-bottom: $space-6;
+  }
+
+  &__result-card-label {
+    font-family: $font-code;
+    font-size: $font-size-xs;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: $color-muted;
+    margin: 0 0 $space-1;
+  }
+
+  &__result-card-text {
+    font-size: $font-size-base;
+    font-weight: $font-weight-medium;
+    color: $color-dark;
+    margin: 0;
+  }
+
+  // --- Captura de lead -----------------------------------------------------
+  &__capture {
+    border-top: 1px solid $color-border;
+    padding-top: $space-6;
+    margin-top: $space-6;
+  }
+
+  &__capture-title {
+    font-family: $font-heading;
+    font-style: italic;
+    font-size: $font-size-xl;
+    color: $color-dark;
+    margin: 0 0 $space-2;
+  }
+
+  &__capture-desc {
+    font-size: $font-size-sm;
+    color: $color-text-light;
+    margin: 0 0 $space-5;
+  }
+
+  &__field { margin-bottom: $space-4; }
+
+  &__label {
+    display: block;
+    font-weight: $font-weight-semibold;
+    font-size: $font-size-sm;
+    color: $color-dark;
+    margin-bottom: $space-2;
+  }
+
+  &__input {
+    width: 100%;
+    font-family: $font-body;
+    font-size: $font-size-base;
+    color: $color-text;
+    background: $color-light;
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+    padding: $space-3 $space-4;
+    transition: border-color $transition-fast, box-shadow $transition-fast;
+
+    &:focus {
+      outline: none;
+      border-color: $color-primary;
+      box-shadow: 0 0 0 3px rgba($color-primary, 0.15);
+    }
+  }
+
+  &__note {
+    font-size: $font-size-xs;
+    color: $color-muted;
+    text-align: center;
+    margin: $space-3 0 0;
+  }
+
+  // --- Sin JavaScript ------------------------------------------------------
+  &__noscript {
+    margin-top: $space-5;
+    padding: $space-4 $space-5;
+    background: $color-light;
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+    font-size: $font-size-sm;
+    color: $color-text-light;
+  }
+}
+
+@keyframes diag-fade {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/src/styles/_diagnostico.scss
+++ b/src/styles/_diagnostico.scss
@@ -2,7 +2,7 @@
 // Diagnóstico exprés — quiz interactivo de captación
 // ==========================================================================
 // Herramienta de 4 preguntas que devuelve una recomendación orientativa y
-// alimenta el embudo (Formspree o mailto). Markup estático, JS progresivo.
+// envía el lead a /api/lead (D1). Markup estático, JS progresivo.
 
 .diag {
   max-width: 720px;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -12,4 +12,5 @@
 @import "animations";
 @import "blog";
 @import "services";
+@import "diagnostico";
 @import "responsive";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,5 +13,17 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "dist"
-  }
+  },
+  // Base de datos D1 para guardar los leads del formulario de contacto y del
+  // diagnóstico exprés. Crea la base con `npx wrangler d1 create eraldia-leads`
+  // y pega aquí el `database_id` que devuelve. Aplica el esquema con
+  // `npx wrangler d1 migrations apply eraldia-leads` (local) y `--remote` (prod).
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "eraldia-leads",
+      "database_id": "REEMPLAZAR_CON_EL_DATABASE_ID_DE_D1",
+      "migrations_dir": "migrations"
+    }
+  ]
 }


### PR DESCRIPTION
Herramienta de 4 preguntas (sector, proceso, horas/semana, situación
actual) que calcula una recomendación orientativa y la conecta con el
embudo existente: campos ocultos en Formspree cuando esté configurado, y
fallback a mailto con el resumen prerrellenado mientras tanto.

- Nueva página src/pages/diagnostico-express.astro (markup estático +
  JS progresivo, con fallback noscript)
- Estilos de marca en src/styles/_diagnostico.scss
- Enlaces en la navegación (header y footer) y CTA en la home