### PR TITLE
Cluster de asesorías, pausa de LinkedIn y aviso de leads por email

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,8 @@
+# Variables/secretos del Worker para desarrollo local con `wrangler dev`.
+# Copia este fichero a `.dev.vars` (ignorado por git) y rellena los valores.
+# En producción NO se usa este fichero: el secreto se sube con
+#   npx wrangler secret put RESEND_API_KEY
+
+# Clave de API de Resend (https://resend.com/api-keys). Sin ella, el lead se
+# guarda igual pero no se envía el aviso por email.
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxx

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,4 +11,9 @@ export const AUTHOR = 'Gorka Alapont';
 // TODO: cambiar por hola@eraldia.com cuando el dominio y el reenvío de correo estén activos
 export const CONTACT_EMAIL = 'alapontgorka@gmail.com';
 
+// Remitente de los avisos de leads (formulario de contacto y diagnóstico exprés).
+// Debe ser una dirección de un dominio verificado en Resend; mientras eraldia.com
+// no esté verificado, usar el remitente de pruebas 'onboarding@resend.dev'.
+export const LEAD_NOTIFY_FROM = 'Eraldia web <web@eraldia.com>';
+
 export const LINKEDIN_URL = '';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,12 +15,19 @@ interface D1Database {
 
 interface CloudflareEnv {
   DB: D1Database;
+  // Clave de API de Resend para enviar el aviso de leads por email.
+  // Es un secreto del Worker: `npx wrangler secret put RESEND_API_KEY`
+  // (en local, en .dev.vars). Puede faltar: el lead se guarda igualmente.
+  RESEND_API_KEY?: string;
 }
 
 declare namespace App {
   interface Locals {
     runtime: {
       env: CloudflareEnv;
+      // En Cloudflare, ctx.waitUntil prolonga la vida del Worker para tareas
+      // en segundo plano (enviar el email sin retrasar la respuesta del form).
+      ctx?: { waitUntil(promise: Promise<unknown>): void };
     };
   }
 }

--- a/src/pages/api/lead.ts
+++ b/src/pages/api/lead.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { url } from '../../utils';
+import { CONTACT_EMAIL, LEAD_NOTIFY_FROM } from '../../consts';
 
 // Endpoint dinámico: no se prerenderiza, se ejecuta en el Worker de Cloudflare.
 export const prerender = false;
@@ -19,6 +20,7 @@ const FIELDS = [
 
 type Field = (typeof FIELDS)[number];
 type LeadData = Partial<Record<Field, string>> & { _gotcha?: string };
+type Lead = Record<Field, string | null>;
 
 function clean(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -55,6 +57,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return reply(wantsJson, 400, { ok: false, error: 'Hace falta un email válido.' });
   }
 
+  // Campos saneados una sola vez: se usan para guardar y para el aviso por email.
+  const lead: Lead = {
+    source: clean(data.source) ?? 'contacto',
+    nombre: clean(data.nombre),
+    email,
+    negocio: clean(data.negocio),
+    mensaje: clean(data.mensaje),
+    sector: clean(data.sector),
+    proceso: clean(data.proceso),
+    horas: clean(data.horas),
+    metodo: clean(data.metodo),
+    recomendacion: clean(data.recomendacion),
+  };
+
   const db = locals.runtime?.env?.DB;
 
   if (!db) {
@@ -74,22 +90,37 @@ export const POST: APIRoute = async ({ request, locals }) => {
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
-        clean(data.source) ?? 'contacto',
-        clean(data.nombre),
-        email,
-        clean(data.negocio),
-        clean(data.mensaje),
-        clean(data.sector),
-        clean(data.proceso),
-        clean(data.horas),
-        clean(data.metodo),
-        clean(data.recomendacion),
+        lead.source,
+        lead.nombre,
+        lead.email,
+        lead.negocio,
+        lead.mensaje,
+        lead.sector,
+        lead.proceso,
+        lead.horas,
+        lead.metodo,
+        lead.recomendacion,
         clean(request.headers.get('user-agent')),
       )
       .run();
   } catch (err) {
     console.error('[api/lead] Error al guardar el lead:', err);
     return reply(wantsJson, 500, { ok: false, error: 'No se pudo guardar el mensaje.' });
+  }
+
+  // Aviso por email a Gorka. No debe afectar a la respuesta del formulario: el
+  // lead ya está guardado. Si hay ctx.waitUntil, se envía en segundo plano para
+  // no añadir latencia; si no, se espera pero se tolera cualquier fallo.
+  const apiKey = locals.runtime?.env?.RESEND_API_KEY;
+  if (apiKey) {
+    const sending = notifyByEmail(apiKey, lead).catch((err) => {
+      console.error('[api/lead] No se pudo enviar el aviso por email:', err);
+    });
+    const waitUntil = locals.runtime?.ctx?.waitUntil;
+    if (waitUntil) waitUntil(sending);
+    else await sending;
+  } else if (!import.meta.env.DEV) {
+    console.warn('[api/lead] RESEND_API_KEY no configurado: lead guardado, sin aviso por email.');
   }
 
   if (wantsJson) {
@@ -101,6 +132,70 @@ export const POST: APIRoute = async ({ request, locals }) => {
     headers: { Location: url('/gracias/') },
   });
 };
+
+// Etiquetas legibles para el correo de aviso.
+const LABELS: Record<Field, string> = {
+  source: 'Origen',
+  nombre: 'Nombre',
+  email: 'Email',
+  negocio: 'Negocio',
+  mensaje: 'Mensaje',
+  sector: 'Sector',
+  proceso: 'Proceso',
+  horas: 'Horas/semana',
+  metodo: 'Cómo lo hace ahora',
+  recomendacion: 'Recomendación mostrada',
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Envía el aviso de un nuevo lead a Gorka vía la API de Resend.
+async function notifyByEmail(apiKey: string, lead: Lead): Promise<void> {
+  const esDiagnostico = lead.source === 'diagnostico';
+  const quien = lead.nombre || lead.email || 'sin nombre';
+  const subject = `Nuevo lead${esDiagnostico ? ' (diagnóstico exprés)' : ' (contacto)'}: ${quien}`;
+
+  const rows = FIELDS.filter((f) => lead[f])
+    .map(
+      (f) =>
+        `<tr><td style="padding:4px 12px 4px 0;color:#6b6256;vertical-align:top;white-space:nowrap;">${LABELS[f]}</td>` +
+        `<td style="padding:4px 0;color:#15120e;">${escapeHtml(lead[f] as string)}</td></tr>`,
+    )
+    .join('');
+
+  const html =
+    `<div style="font-family:Inter,Arial,sans-serif;font-size:15px;line-height:1.5;color:#15120e;">` +
+    `<p style="margin:0 0 16px;">Nuevo lead desde la web de Eraldia.</p>` +
+    `<table style="border-collapse:collapse;">${rows}</table>` +
+    `<p style="margin:16px 0 0;color:#6b6256;">Responde directamente a este correo para contestar al lead.</p>` +
+    `</div>`;
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: LEAD_NOTIFY_FROM,
+      to: [CONTACT_EMAIL],
+      subject,
+      html,
+      // Responder al correo de aviso escribe directamente al lead.
+      ...(lead.email ? { reply_to: lead.email } : {}),
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Resend respondió ${res.status}: ${await res.text()}`);
+  }
+}
 
 function reply(json: boolean, status: number, body: Record<string, unknown>): Response {
   if (json) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,6 +14,11 @@
     "binding": "ASSETS",
     "directory": "dist"
   },
+  // El aviso de leads por email usa Resend. La clave NO va aquí (es un secreto):
+  //   npx wrangler secret put RESEND_API_KEY
+  // En local, ponla en .dev.vars (ver .dev.vars.example). El remitente está en
+  // src/consts.ts (LEAD_NOTIFY_FROM) y debe ser un dominio verificado en Resend.
+  //
   // Base de datos D1 para guardar los leads del formulario de contacto y del
   // diagnóstico exprés. Crea la base con `npx wrangler d1 create eraldia-leads`
   // y pega aquí el `database_id` que devuelve. Aplica el esquema con


### PR DESCRIPTION
Tres bloques de trabajo independientes.

## 1. Contenido: cluster de IA para asesorías
Cuatro piezas nuevas en la cola editorial (`content-queue/posts/`) que profundizan el sector asesorías/gestorías más allá del post overview existente, cada una con su versión nativa de LinkedIn y siguiendo la plantilla GEO (respuesta directa, cifras 2026, tablas, FAQs, frase citable, enlaces a servicios y a la landing de gestorías):

- **11** — IA en la campaña de Renta sin contratar refuerzos
- **12** — Registro de facturas con IA explicado por dentro
- **13** — Onboarding de clientes nuevos en la gestoría
- **14** — Usar IA cumpliendo el RGPD

## 2. Pausa de la publicación en LinkedIn
Nuevo interruptor `SKIP_LINKEDIN` en `tools/publish-next.mjs` que detiene **solo** la publicación social (sin tocar la web ni la cadencia) y conserva el `.linkedin.md` en la cola. Activado con `SKIP_LINKEDIN=1` en `.github/workflows/publish-content.yml`. Para reanudar: poner la variable a `""` o borrar la línea.

## 3. Aviso de leads por email (Resend)
El endpoint `/api/lead` guardaba el lead en D1 pero nunca enviaba el correo prometido. Ahora, tras guardar, envía un aviso a Gorka (`CONTACT_EMAIL`) con todos los datos del lead vía la API de Resend:

- Se envía en segundo plano con `ctx.waitUntil` para no retrasar el formulario.
- Tolera fallos: si Resend o la clave fallan, el lead ya está guardado.
- `reply_to` apunta al email del lead para poder responderle directamente.
- Remitente configurable en `src/consts.ts` (`LEAD_NOTIFY_FROM`); clave `RESEND_API_KEY` como secreto del Worker (`.dev.vars.example` para local).

### Pendiente para activar el email (pasos manuales)
1. Verificar `eraldia.com` en Resend (registros DNS SPF/DKIM).
2. Crear API key y subirla: `npx wrangler secret put RESEND_API_KEY`.
3. Desplegar en Cloudflare Pages (requiere Worker + D1; no funciona en GitHub Pages).

## Notas
- El build de Astro pasa (`npm run build`).
- La pausa de LinkedIn solo surte efecto al mergear a `main` (el cron corre sobre la rama por defecto).

https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru

---
_Generated by [Claude Code](https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru)_