### PR TITLE
Correo del sitio: hola@eraldia.com (público, destino y remitente de avisos)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,7 +10,7 @@ export const AUTHOR = 'Gorka Alapont';
 
 // Correo del dominio (Proton). Es el email público (footer, contacto) y el
 // destino de los avisos de leads que envía /api/lead.
-export const CONTACT_EMAIL = 'hello@eraldia.com';
+export const CONTACT_EMAIL = 'hola@eraldia.com';
 
 // Remitente de los avisos de leads (formulario de contacto y diagnóstico exprés).
 // Debe ser una dirección de un dominio verificado en Resend; mientras eraldia.com

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -15,6 +15,6 @@ export const CONTACT_EMAIL = 'hola@eraldia.com';
 // Remitente de los avisos de leads (formulario de contacto y diagnóstico exprés).
 // Debe ser una dirección de un dominio verificado en Resend; mientras eraldia.com
 // no esté verificado, usar el remitente de pruebas 'onboarding@resend.dev'.
-export const LEAD_NOTIFY_FROM = 'Eraldia web <web@eraldia.com>';
+export const LEAD_NOTIFY_FROM = 'Eraldia <hola@eraldia.com>';
 
 export const LINKEDIN_URL = '';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,8 +8,9 @@ export const SITE_DESCRIPTION =
 export const TAGLINE = 'Pon tu pyme al día con la IA';
 export const AUTHOR = 'Gorka Alapont';
 
-// TODO: cambiar por hola@eraldia.com cuando el dominio y el reenvío de correo estén activos
-export const CONTACT_EMAIL = 'alapontgorka@gmail.com';
+// Correo del dominio (Proton). Es el email público (footer, contacto) y el
+// destino de los avisos de leads que envía /api/lead.
+export const CONTACT_EMAIL = 'hello@eraldia.com';
 
 // Remitente de los avisos de leads (formulario de contacto y diagnóstico exprés).
 // Debe ser una dirección de un dominio verificado en Resend; mientras eraldia.com

--- a/tools/setup-proton-dns.sh
+++ b/tools/setup-proton-dns.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Configura en Cloudflare los registros DNS para recibir email en hola@eraldia.com
+# con Proton Mail. Pensado para ejecutarse en TU máquina (necesita tu token de
+# Cloudflare). No commitees este fichero con valores reales rellenados.
+#
+# Antes de ejecutar:
+#   1. Cloudflare -> Email -> Email Routing -> DESACTIVAR (si está activo, sus MX
+#      bloquean los de Proton y no recibirás nada).
+#   2. Proton -> Settings -> All settings -> Domain names -> eraldia.com:
+#      copia el TXT de verificación y los 3 valores CNAME de DKIM aquí abajo.
+#   3. Crea un API token en Cloudflare con permiso "Zone.DNS:Edit" sobre eraldia.com
+#      y expórtalo:  export CF_API_TOKEN=...   (no lo pegues en chats ni en git)
+#
+# Uso:  CF_API_TOKEN=... bash setup-proton-dns.sh
+set -euo pipefail
+
+ZONE_NAME="eraldia.com"
+
+# --- Rellena estos 4 valores con lo que te muestra Proton -------------------
+PROTON_VERIFICATION="protonmail-verification=XXXXXXXXXXXXXXXX"
+DKIM1="protonmail.domainkey.dXXXXXXXX.domains.proton.ch"
+DKIM2="protonmail2.domainkey.dXXXXXXXX.domains.proton.ch"
+DKIM3="protonmail3.domainkey.dXXXXXXXX.domains.proton.ch"
+# ---------------------------------------------------------------------------
+
+: "${CF_API_TOKEN:?Exporta CF_API_TOKEN con un token Zone.DNS:Edit}"
+API="https://api.cloudflare.com/client/v4"
+auth=(-H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json")
+
+# Localiza el zone id del dominio
+ZONE_ID=$(curl -s "${auth[@]}" "${API}/zones?name=${ZONE_NAME}" | python3 -c \
+  'import sys,json;print(json.load(sys.stdin)["result"][0]["id"])')
+echo "Zone: ${ZONE_NAME} -> ${ZONE_ID}"
+
+# Crea un registro (idempotencia básica: avisa si Cloudflare lo rechaza por duplicado)
+add() { # tipo nombre contenido [prioridad]
+  local type="$1" name="$2" content="$3" prio="${4:-}"
+  local data
+  if [[ -n "$prio" ]]; then
+    data=$(printf '{"type":"%s","name":"%s","content":"%s","priority":%s,"ttl":1,"proxied":false}' "$type" "$name" "$content" "$prio")
+  else
+    data=$(printf '{"type":"%s","name":"%s","content":"%s","ttl":1,"proxied":false}' "$type" "$name" "$content")
+  fi
+  echo "-> ${type} ${name}"
+  curl -s "${auth[@]}" -X POST "${API}/zones/${ZONE_ID}/dns_records" -d "$data" \
+    | python3 -c 'import sys,json;r=json.load(sys.stdin);print("   OK" if r["success"] else "   "+str(r["errors"]))'
+}
+
+# Recibir (MX) + verificación de dominio
+add TXT "@"                       "$PROTON_VERIFICATION"
+add MX  "@"                       "mail.protonmail.ch"    10
+add MX  "@"                       "mailsec.protonmail.ch" 20
+
+# SPF (un único registro SPF en la raíz; si ya hay uno, este fallará: edítalo a mano)
+add TXT "@"                       "v=spf1 include:_spf.protonmail.ch ~all"
+
+# DKIM (CNAME, sin proxy)
+add CNAME "protonmail._domainkey"  "$DKIM1"
+add CNAME "protonmail2._domainkey" "$DKIM2"
+add CNAME "protonmail3._domainkey" "$DKIM3"
+
+# DMARC
+add TXT "_dmarc"                  "v=DMARC1; p=quarantine;"
+
+echo "Hecho. Vuelve a Proton -> Domain names y pulsa Verify."


### PR DESCRIPTION
Cambios posteriores al PR #56 (ya mergeado), que activan el correo del dominio.

## Correo del sitio
- `CONTACT_EMAIL` pasa de la dirección provisional de Gmail a **`hola@eraldia.com`** (Proton). Alimenta el email público (footer, formulario de contacto) y el **destino de los avisos de leads** de `/api/lead`.
- `LEAD_NOTIFY_FROM` ahora envía los avisos **desde `hola@eraldia.com`** (debe ser un dominio verificado en Resend).

## Helper de DNS
- `tools/setup-proton-dns.sh`: script opcional para crear vía API de Cloudflare los registros MX/SPF/DKIM/DMARC + el TXT de verificación que Proton necesita para **recibir** correo. Se ejecuta en local con un token propio; los valores únicos de Proton se rellenan a mano.

## Notas
- El build de Astro pasa (`npm run build`).
- Recepción (Proton) y envío (Resend) conviven en el mismo dominio: Proton en la raíz y `protonmail*._domainkey`; Resend en el subdominio `send` y `resend._domainkey`. Sin conflicto.
- Pendiente fuera del repo: dominio verificado en Resend y `RESEND_API_KEY` como secreto del Worker en Cloudflare Pages.

https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru

---
_Generated by [Claude Code](https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru)_