### PR TITLE
Arreglar el formulario del diagnóstico: POST a /api/lead/ con barra final

### DIFF
--- a/src/pages/diagnostico-express.astro
+++ b/src/pages/diagnostico-express.astro
@@ -109,7 +109,7 @@ const checkIcon =
             concretas para tu caso. Sin newsletters: solo esta respuesta.
           </p>
 
-          <form class="diag__form" id="diag-form" action={url('/api/lead')} method="POST">
+          <form class="diag__form" id="diag-form" action={url('/api/lead/')} method="POST">
             <input type="hidden" name="source" value="diagnostico">
             <div class="diag__field">
               <label class="diag__label" for="diag-nombre">Nombre</label>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -195,7 +195,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts'
       </p>
     </div>
 
-    <form class="contact-form reveal" id="contact-form" action={url('/api/lead')} method="POST" data-email={CONTACT_EMAIL}>
+    <form class="contact-form reveal" id="contact-form" action={url('/api/lead/')} method="POST" data-email={CONTACT_EMAIL}>
       <input type="hidden" name="source" value="contacto">
       <div class="contact-form__row">
         <div class="contact-form__field">


### PR DESCRIPTION
## Problema
Al completar el formulario del diagnóstico exprés (y el de contacto), aparecía el error *"No se pudo enviar"*.

**Causa:** con `trailingSlash: 'always'` el endpoint solo existe en `/api/lead/`, pero los formularios hacían `POST` a `/api/lead` (sin barra), que devuelve **404**. El `fetch` recibía la página HTML de error, fallaba al parsear JSON y mostraba el mensaje de error, aunque el lead nunca se intentaba guardar.

## Solución
Cambiar la `action` de ambos formularios a `/api/lead/` (con barra):
- `src/pages/diagnostico-express.astro`
- `src/pages/index.astro`

## Verificación (local)
- `POST /api/lead` → 404 (HTML de "no encontrada")
- `POST /api/lead/` → **200 `{"ok":true}`** y el lead queda guardado en D1 (tras aplicar las migraciones a la base local).
- `npm run build` pasa.

> Nota: el endpoint solo funciona en Cloudflare Pages (Worker + D1), no en GitHub Pages.

https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru

---
_Generated by [Claude Code](https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru)_