### PR TITLE
Enviar los avisos de leads a gorka@eraldia.com

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,9 +8,12 @@ export const SITE_DESCRIPTION =
 export const TAGLINE = 'Pon tu pyme al día con la IA';
 export const AUTHOR = 'Gorka Alapont';
 
-// Correo del dominio (Proton). Es el email público (footer, contacto) y el
-// destino de los avisos de leads que envía /api/lead.
+// Correo público del dominio (Proton): footer, formulario, NAP.
 export const CONTACT_EMAIL = 'hola@eraldia.com';
+
+// Destinatario interno de los avisos de leads que envía /api/lead (puede ser
+// distinto del email público de arriba).
+export const LEAD_NOTIFY_TO = 'gorka@eraldia.com';
 
 // Remitente de los avisos de leads (formulario de contacto y diagnóstico exprés).
 // Debe ser una dirección de un dominio verificado en Resend; mientras eraldia.com

--- a/src/pages/api/email-check.ts
+++ b/src/pages/api/email-check.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { CONTACT_EMAIL, LEAD_NOTIFY_FROM } from '../../consts';
+import { LEAD_NOTIFY_TO, LEAD_NOTIFY_FROM } from '../../consts';
 
 // Endpoint de diagnóstico TEMPORAL para confirmar, tras un deploy, que el
 // Worker ve la RESEND_API_KEY y que Resend la acepta. Nunca devuelve el valor
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ url, locals }) => {
     resendKeyPresent: keyPresent,
     dbBound: Boolean(env?.DB),
     from: LEAD_NOTIFY_FROM,
-    to: CONTACT_EMAIL,
+    to: LEAD_NOTIFY_TO,
   };
 
   if (url.searchParams.get('ping') === '1' && keyPresent) {

--- a/src/pages/api/lead.ts
+++ b/src/pages/api/lead.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { url } from '../../utils';
-import { CONTACT_EMAIL, LEAD_NOTIFY_FROM } from '../../consts';
+import { LEAD_NOTIFY_TO, LEAD_NOTIFY_FROM } from '../../consts';
 
 // Endpoint dinámico: no se prerenderiza, se ejecuta en el Worker de Cloudflare.
 export const prerender = false;
@@ -184,7 +184,7 @@ async function notifyByEmail(apiKey: string, lead: Lead): Promise<void> {
     },
     body: JSON.stringify({
       from: LEAD_NOTIFY_FROM,
-      to: [CONTACT_EMAIL],
+      to: [LEAD_NOTIFY_TO],
       subject,
       html,
       // Responder al correo de aviso escribe directamente al lead.


### PR DESCRIPTION
## Cambio
Los avisos de leads pasan a enviarse a **`gorka@eraldia.com`**, separándolo del email público del sitio.

- Nueva constante `LEAD_NOTIFY_TO = 'gorka@eraldia.com'` → destinatario interno de los avisos de `/api/lead`.
- `CONTACT_EMAIL = 'hola@eraldia.com'` se mantiene como **email público** (footer, formulario, NAP).
- `LEAD_NOTIFY_FROM` sigue siendo `Eraldia <hola@eraldia.com>`.
- `/api/email-check` actualizado para reflejar el `to` real.

## Verificación
- `npm run build` pasa.
- `src/pages/api/lead.ts` → `to: [LEAD_NOTIFY_TO]`.

> Nota: asegúrate de que `gorka@eraldia.com` existe como buzón/alias en Proton, o Resend enviará pero rebotará. Resend ya da 200 + dominio `verified`.

https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru

---
_Generated by [Claude Code](https://claude.ai/code/session_012jaZs42Q28oSpwMr3fT2Ru)_