### PR TITLE
Vincular la D1 real de Cloudflare (database_id correcto)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,7 +27,7 @@
     {
       "binding": "DB",
       "database_name": "eraldia-leads",
-      "database_id": "57d52d04-21f0-46ae-b22e-c56eebd0ffa3",
+      "database_id": "e109e041-40f2-4bd0-aa86-c35d377b07eb",
       "migrations_dir": "migrations"
     }
   ]


### PR DESCRIPTION
## Problema

El código de D1 ya estaba en `main`, pero el `database_id` de `wrangler.jsonc`
(`57d52d04-…`) no correspondía a ninguna base real. La D1 de la cuenta
(`eraldia-leads`) tiene el uuid `e109e041-40f2-4bd0-aa86-c35d377b07eb` y además
estaba vacía (`num_tables: 0`): las migraciones nunca se aplicaron. En
producción el binding `DB` no apuntaba a nada y los leads del formulario de
contacto y del diagnóstico exprés **no se guardaban**.

## Cambios

- Corregido el `database_id` en `wrangler.jsonc` con el uuid real de la base.
- Aplicada la migración `0001_create_leads.sql` en la D1 **remota**: ahora
  tiene la tabla `leads`, los índices `idx_leads_created_at` /
  `idx_leads_source` y el tracking `d1_migrations`.
- Verificado con `npm run build` y consulta del esquema remoto.

## Pendiente tras el merge

- Re-desplegar a Cloudflare para que el Worker de producción use el
  `database_id` corregido.
- Confirmar que el secreto `RESEND_API_KEY` está configurado en prod (si no,
  el lead se guarda pero no llega el aviso por email).

https://claude.ai/code/session_015vUNDvPRbdAVKNkgD1dG7N

---
_Generated by [Claude Code](https://claude.ai/code/session_015vUNDvPRbdAVKNkgD1dG7N)_