### PR TITLE
Reducir la visibilidad de los precios en la web

### DIFF
--- a/src/content/blog/cuanto-cuesta-automatizacion-ia-pyme.md
+++ b/src/content/blog/cuanto-cuesta-automatizacion-ia-pyme.md
@@ -37,7 +37,7 @@ A estos precios hay que sumar el coste de las herramientas (suscripciones de IA 
 - No te saben decir qué pasa si la IA se equivoca.
 - El presupuesto no distingue entre implantación y mantenimiento.
 
-En [Eraldia](/servicios/) trabajo siempre con precio cerrado: [diagnóstico](/servicios/diagnostico-ia/) por 490 €, [automatización a medida](/servicios/automatizacion/) desde 1.900 € y [acompañamiento mensual](/servicios/acompanamiento/) desde 390 €/mes, sin permanencia. Atiendo en remoto a toda España, con base en Bilbao y actividad regular en Andalucía.
+En [Eraldia](/servicios/) trabajo siempre con precio cerrado y acordado por escrito antes de empezar: un [diagnóstico](/servicios/diagnostico-ia/) de entrada que se descuenta del proyecto, la [automatización a medida](/servicios/automatizacion/) según el alcance y un [acompañamiento mensual](/servicios/acompanamiento/) opcional, sin permanencia. El importe exacto depende de tu caso; lo aterrizamos en la llamada. Atiendo en remoto a toda España, con base en Bilbao y actividad regular en Andalucía.
 
 ## Preguntas frecuentes
 

--- a/src/content/blog/que-hace-consultor-ia-pyme.md
+++ b/src/content/blog/que-hace-consultor-ia-pyme.md
@@ -31,7 +31,7 @@ Un consultor de IA para pymes hace tres cosas: **identifica qué procesos de tu 
 
 ## Cuánto cuesta (2026)
 
-Con precios de 2026, un diagnóstico ronda los 400 € – 700 € y cada automatización implantada entre 1.900 € y 4.500 €. Publiqué los rangos completos en [la guía de precios](/blog/cuanto-cuesta-automatizacion-ia-pyme/).
+Los precios de mercado en 2026 se mueven en rangos amplios según el proyecto: un diagnóstico de entrada cuesta unos cientos de euros y cada automatización implantada, una horquilla de unos pocos miles. Publiqué el desglose completo, con sus rangos orientativos, en [la guía de precios](/blog/cuanto-cuesta-automatizacion-ia-pyme/).
 
 En mi caso: trabajo en solitario, con precio cerrado y sin intermediarios, desde Bilbao y en remoto para toda España — con especial actividad en el País Vasco y Andalucía. Puedes ver [cómo trabajo](/sobre-mi/) o empezar por un [diagnóstico](/servicios/diagnostico-ia/).
 

--- a/src/content/sectores/clinicas.md
+++ b/src/content/sectores/clinicas.md
@@ -2,7 +2,7 @@
 title: "IA para clínicas y centros de salud"
 badge: "Salud"
 description: "Dentistas, fisios, veterinarias... Los pacientes esperan respuesta inmediata y el personal no da abasto. La IA atiende lo repetitivo y reduce las ausencias."
-metaDescription: "Automatización con IA para clínicas dentales, de fisioterapia y veterinarias: citas con recordatorios que reducen ausencias, asistente para dudas frecuentes y seguimiento de tratamientos. Precio cerrado desde 1.900 €."
+metaDescription: "Automatización con IA para clínicas dentales, de fisioterapia y veterinarias: citas con recordatorios que reducen ausencias, asistente para dudas frecuentes y seguimiento de tratamientos. Con precio cerrado y herramientas a tu nombre."
 image: "/images/use-cases/healthcare.jpg"
 imageAlt: "Equipo de una clínica usando herramientas digitales"
 weight: 2
@@ -44,4 +44,4 @@ El flujo de una clínica dental, una de fisioterapia o una veterinaria es muy pa
 
 ## Cómo lo hacemos
 
-Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €): en dos semanas tienes claras las 2-3 automatizaciones con más impacto y su coste cerrado. Si seguimos, la [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), con el equipo formado y un mes de soporte. Las herramientas se contratan a tu nombre.
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/): en dos semanas tienes claras las 2-3 automatizaciones con más impacto y su coste cerrado. Si seguimos, la [implantación](/servicios/automatizacion/) se hace con precio cerrado por escrito, el equipo formado y un mes de soporte. Las herramientas se contratan a tu nombre.

--- a/src/content/sectores/gimnasios.md
+++ b/src/content/sectores/gimnasios.md
@@ -2,7 +2,7 @@
 title: "IA para gimnasios y centros deportivos"
 badge: "Deporte"
 description: "El crecimiento depende del seguimiento constante y de la retención de socios. La IA hace ese seguimiento que, con el día a día, siempre se queda a medias."
-metaDescription: "Automatización con IA para gimnasios y centros deportivos: seguimiento automático de interesados, bienvenida personalizada y señales de abandono para reducir bajas. Precio cerrado desde 1.900 €."
+metaDescription: "Automatización con IA para gimnasios y centros deportivos: seguimiento automático de interesados, bienvenida personalizada y señales de abandono para reducir bajas. Con precio cerrado y herramientas a tu nombre."
 image: "/images/use-cases/fitness.jpg"
 imageAlt: "Socio de gimnasio entrenando con su monitor"
 weight: 3
@@ -20,7 +20,7 @@ faqs:
   - q: "¿Cómo detecta que un socio se va a dar de baja?"
     a: "Con señales como la caída de asistencia o la falta de reserva de clases. Cuando aparecen, salta un aviso para que el equipo actúe a tiempo, en vez de enterarse cuando ya ha pedido la baja."
   - q: "¿Cuánto cuesta y en cuánto tiempo funciona?"
-    a: "El diagnóstico (desde 490 €) prioriza en dos semanas lo que más mueve la aguja. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026)."
+    a: "El diagnóstico prioriza en dos semanas lo que más mueve la aguja y cierra su coste. La implantación se hace con precio cerrado por escrito, en 2-4 semanas."
 ---
 
 ## El crecimiento de un gimnasio se cae por el seguimiento
@@ -37,4 +37,4 @@ La automatización se ocupa de ese seguimiento constante que nunca falla por fal
 
 ## Cómo lo hacemos
 
-Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €) que prioriza dónde está el mayor retorno: captación, conversión o retención. La [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), con el equipo formado y las herramientas a tu nombre.
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) que prioriza dónde está el mayor retorno: captación, conversión o retención. La [implantación](/servicios/automatizacion/) se hace con precio cerrado por escrito, el equipo formado y las herramientas a tu nombre.

--- a/src/content/sectores/inmobiliarias.md
+++ b/src/content/sectores/inmobiliarias.md
@@ -2,7 +2,7 @@
 title: "IA para inmobiliarias y agentes"
 badge: "Inmobiliario"
 description: "Quien responde primero, se lleva la operación. La IA cualifica y sigue cada contacto al momento, para que ningún lead se enfríe en la bandeja de entrada."
-metaDescription: "Automatización con IA para inmobiliarias y agentes: respuesta inmediata y cualificación de leads, seguimiento automático de interesados y publicación de inmuebles sin picar datos. Precio cerrado desde 1.900 €."
+metaDescription: "Automatización con IA para inmobiliarias y agentes: respuesta inmediata y cualificación de leads, seguimiento automático de interesados y publicación de inmuebles sin picar datos. Con precio cerrado y herramientas a tu nombre."
 weight: 4
 featured: false
 bullets:
@@ -35,4 +35,4 @@ La automatización con IA cubre exactamente ese hueco: atención inmediata y seg
 
 ## Cómo lo hacemos
 
-Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) (desde 490 €) que identifica dónde se te escapan más operaciones. La [implantación](/servicios/automatizacion/) va de 1.900 € a 4.500 € (precios de 2026), precio cerrado, con las herramientas a tu nombre. ¿Encaja en tu agencia? [Hablamos 30 minutos, gratis](/#contacto).
+Empezamos por un [diagnóstico](/servicios/diagnostico-ia/) que identifica dónde se te escapan más operaciones. La [implantación](/servicios/automatizacion/) se hace con precio cerrado por escrito y las herramientas a tu nombre. ¿Encaja en tu agencia? [Hablamos 30 minutos, gratis](/#contacto).

--- a/src/content/servicios/acompanamiento.md
+++ b/src/content/servicios/acompanamiento.md
@@ -1,6 +1,6 @@
 ---
 title: "Acompañamiento mensual"
-description: "Tu socio tecnológico sin contratar a nadie: mantenimiento de las automatizaciones, mejoras continuas y formación para tu equipo. Desde 390 €/mes, sin permanencia."
+description: "Tu socio tecnológico sin contratar a nadie: mantenimiento de las automatizaciones, mejoras continuas y formación para tu equipo. Cuota mensual cerrada, sin permanencia."
 weight: 3
 icon: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>'
 ---
@@ -22,6 +22,6 @@ Para negocios que ya tienen alguna automatización funcionando (conmigo o por su
 
 ## Precio y condiciones
 
-**Desde 390 €/mes (IVA aparte), sin permanencia.** Puedes darte de baja cualquier mes avisando con 30 días. El alcance exacto (horas incluidas, tiempos de respuesta) se acuerda por escrito al empezar.
+**Cuota mensual cerrada (IVA aparte), sin permanencia.** Puedes darte de baja cualquier mes avisando con 30 días. La cuota y el alcance exacto (horas incluidas, tiempos de respuesta) se acuerdan por escrito al empezar, según lo que necesites.
 
 La mejor forma de saber si te encaja: una [llamada gratuita de 30 minutos](/#contacto).

--- a/src/content/servicios/automatizacion.md
+++ b/src/content/servicios/automatizacion.md
@@ -1,6 +1,6 @@
 ---
 title: "Automatización a medida"
-description: "Implanto la automatización en tu negocio en 2-4 semanas: atención al cliente, presupuestos, facturación, informes... Proyecto cerrado en alcance, plazo y precio. Desde 1.900 €."
+description: "Implanto la automatización en tu negocio en 2-4 semanas: atención al cliente, presupuestos, facturación, informes... Proyecto cerrado en alcance, plazo y precio."
 weight: 2
 icon: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>'
 ---
@@ -27,6 +27,6 @@ Aquí es donde el plan se convierte en realidad. Cojo una de las automatizacione
 
 ## Precio y condiciones
 
-**Desde 1.900 € (IVA aparte) por proyecto, precio cerrado.** El plazo habitual es de 2 a 4 semanas según la complejidad. Si vienes del [diagnóstico](/servicios/diagnostico-ia/), su importe se descuenta.
+**Precio cerrado por proyecto (IVA aparte), acordado por escrito antes de empezar.** El importe depende del alcance y de cuántos sistemas haya que conectar; el plazo habitual es de 2 a 4 semanas según la complejidad. Si vienes del [diagnóstico](/servicios/diagnostico-ia/), su importe se descuenta.
 
 Las herramientas que se usen (suscripciones de Make, APIs de IA, etc.) se contratan **a tu nombre**: el sistema es tuyo, no me necesitas para que siga funcionando.

--- a/src/content/servicios/diagnostico-ia.md
+++ b/src/content/servicios/diagnostico-ia.md
@@ -1,6 +1,6 @@
 ---
 title: "Diagnóstico de IA y Automatización"
-description: "En dos semanas te digo exactamente qué procesos de tu negocio merece la pena automatizar, cuánto cuesta hacerlo y qué ahorro puedes esperar. Precio cerrado: desde 490 €."
+description: "En dos semanas te digo exactamente qué procesos de tu negocio merece la pena automatizar, cuánto cuesta hacerlo y qué ahorro puedes esperar. Con un presupuesto cerrado, sin sorpresas."
 weight: 1
 icon: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>'
 ---
@@ -28,6 +28,6 @@ Eso es exactamente lo que entrego con el diagnóstico.
 
 ## Precio y condiciones
 
-**Desde 490 € (IVA aparte), precio cerrado.** Dos semanas de plazo. Si después contratas la implantación conmigo, **el diagnóstico se descuenta del proyecto**.
+**Precio cerrado (IVA aparte) y dos semanas de plazo.** Te paso el importe exacto antes de empezar, sin sorpresas. Si después contratas la implantación conmigo, **el diagnóstico se descuenta del proyecto**.
 
 ¿Dudas de si te encaja? Empieza por la [llamada gratuita de 30 minutos](/#contacto): si veo que un diagnóstico no te va a aportar, te lo digo y no perdemos el tiempo ninguno de los dos.

--- a/src/pages/ia-para-abogados.astro
+++ b/src/pages/ia-para-abogados.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 const title = 'IA para despachos de abogados';
 const description =
-  'Automatización con IA para despachos de abogados: resumen y búsqueda en expedientes, control de plazos procesales, intake de clientes y consultas repetitivas. Menos horas administrativas, más horas facturables. Precio cerrado desde 1.900 € (2026).';
+  'Automatización con IA para despachos de abogados: resumen y búsqueda en expedientes, control de plazos procesales, intake de clientes y consultas repetitivas. Menos horas administrativas, más horas facturables. Proyectos con precio cerrado, sin humo.';
 
 const updated = '2026-06-14';
 
@@ -53,7 +53,7 @@ const faqs = [
   },
   {
     q: '¿Cuánto cuesta y cuánto tarda?',
-    a: 'El diagnóstico (desde 490 €) prioriza en dos semanas las automatizaciones con más retorno. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026).',
+    a: 'El diagnóstico prioriza en dos semanas las automatizaciones con más retorno y cierra el presupuesto de cada una. La implantación se hace en 2-4 semanas, siempre con el precio acordado por escrito antes de empezar.',
   },
   {
     q: '¿Sirve para un despacho pequeño o un abogado individual?',
@@ -73,12 +73,6 @@ const serviceSchema = {
   description,
   areaServed: { '@type': 'Country', name: 'España' },
   provider: { '@type': 'ProfessionalService', name: 'Eraldia', url: new URL(url('/'), Astro.url).href },
-  offers: {
-    '@type': 'Offer',
-    priceCurrency: 'EUR',
-    price: '490',
-    description: 'Diagnóstico de IA desde 490 € (precios de 2026); implantación de 1.900 € a 4.500 €.',
-  },
 };
 
 const faqSchema = {
@@ -197,18 +191,18 @@ const faqSchema = {
 <section class="section">
   <div class="container container--narrow">
     <div class="section__header">
-      <h2 class="section__title">Cómo lo hacemos (y qué cuesta)</h2>
-      <p class="section__subtitle">Una escalera con precio cerrado en cada escalón. Empiezas por el primero y decides después.</p>
+      <h2 class="section__title">Cómo lo hacemos</h2>
+      <p class="section__subtitle">Una escalera de tres pasos, con precio cerrado por escrito en cada uno. Empiezas por el primero y decides después.</p>
     </div>
     <div class="pb-table-wrap">
       <table class="pb-table">
         <thead>
-          <tr><th>Paso</th><th>Qué recibes</th><th>Precio 2026</th></tr>
+          <tr><th>Paso</th><th>Qué recibes</th></tr>
         </thead>
         <tbody>
-          <tr><td><a href={url('/servicios/diagnostico-ia/')}>Diagnóstico de IA</a></td><td>En 2 semanas: el mapa de tus procesos, las automatizaciones con más retorno y qué información puede tratarse.</td><td>desde 490 €</td></tr>
-          <tr><td><a href={url('/servicios/automatizacion/')}>Automatización a medida</a></td><td>Implantación en 2-4 semanas, equipo formado y herramientas a tu nombre.</td><td>1.900 – 4.500 €</td></tr>
-          <tr><td><a href={url('/servicios/acompanamiento/')}>Acompañamiento</a></td><td>Mantenimiento, mejoras y formación continua, sin permanencia.</td><td>desde 390 €/mes</td></tr>
+          <tr><td><a href={url('/servicios/diagnostico-ia/')}>Diagnóstico de IA</a></td><td>En 2 semanas: el mapa de tus procesos, las automatizaciones con más retorno y qué información puede tratarse.</td></tr>
+          <tr><td><a href={url('/servicios/automatizacion/')}>Automatización a medida</a></td><td>Implantación en 2-4 semanas, equipo formado y herramientas a tu nombre.</td></tr>
+          <tr><td><a href={url('/servicios/acompanamiento/')}>Acompañamiento</a></td><td>Mantenimiento, mejoras y formación continua, sin permanencia.</td></tr>
         </tbody>
       </table>
     </div>

--- a/src/pages/ia-para-asesorias.astro
+++ b/src/pages/ia-para-asesorias.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 const title = 'IA para asesorías y gestorías';
 const description =
-  'Automatización con IA para asesorías y gestorías: picado de facturas y nóminas, recordatorios de plazos, respuestas a consultas y onboarding. Menos horas administrativas y más capacidad para crecer. Precio cerrado desde 1.900 € (2026).';
+  'Automatización con IA para asesorías y gestorías: picado de facturas y nóminas, recordatorios de plazos, respuestas a consultas y onboarding. Menos horas administrativas y más capacidad para crecer. Proyectos con precio cerrado, sin humo.';
 
 const updated = '2026-06-14';
 
@@ -55,7 +55,7 @@ const faqs = [
   },
   {
     q: '¿Cuánto se tarda y cuánto cuesta?',
-    a: 'Un diagnóstico (desde 490 €) te dice en dos semanas qué procesos compensa automatizar y cuánto ahorras. La implantación va de 1.900 € a 4.500 €, precio cerrado, en 2-4 semanas (precios de 2026).',
+    a: 'Un diagnóstico te dice en dos semanas qué procesos compensa automatizar, cuánto ahorras y cuánto costaría implantarlo, con un presupuesto cerrado por escrito. La implantación se hace en 2-4 semanas, siempre con el precio acordado antes de empezar.',
   },
   {
     q: '¿Sirve para una asesoría pequeña?',
@@ -75,12 +75,6 @@ const serviceSchema = {
   description,
   areaServed: { '@type': 'Country', name: 'España' },
   provider: { '@type': 'ProfessionalService', name: 'Eraldia', url: new URL(url('/'), Astro.url).href },
-  offers: {
-    '@type': 'Offer',
-    priceCurrency: 'EUR',
-    price: '490',
-    description: 'Diagnóstico de IA desde 490 € (precios de 2026); implantación de 1.900 € a 4.500 €.',
-  },
 };
 
 const faqSchema = {
@@ -182,18 +176,18 @@ const faqSchema = {
 <section class="section section--alt">
   <div class="container container--narrow">
     <div class="section__header">
-      <h2 class="section__title">Cómo lo hacemos (y qué cuesta)</h2>
-      <p class="section__subtitle">Una escalera con precio cerrado en cada escalón. Empiezas por el primero y decides después.</p>
+      <h2 class="section__title">Cómo lo hacemos</h2>
+      <p class="section__subtitle">Una escalera de tres pasos, con precio cerrado por escrito en cada uno. Empiezas por el primero y decides después.</p>
     </div>
     <div class="pb-table-wrap">
       <table class="pb-table">
         <thead>
-          <tr><th>Paso</th><th>Qué recibes</th><th>Precio 2026</th></tr>
+          <tr><th>Paso</th><th>Qué recibes</th></tr>
         </thead>
         <tbody>
-          <tr><td><a href={url('/servicios/diagnostico-ia/')}>Diagnóstico de IA</a></td><td>En 2 semanas: el mapa de tus procesos, las 2-3 automatizaciones con más ahorro y su coste cerrado.</td><td>desde 490 €</td></tr>
-          <tr><td><a href={url('/servicios/automatizacion/')}>Automatización a medida</a></td><td>Implantación en 2-4 semanas, equipo formado y herramientas a tu nombre.</td><td>1.900 – 4.500 €</td></tr>
-          <tr><td><a href={url('/servicios/acompanamiento/')}>Acompañamiento</a></td><td>Mantenimiento, mejoras y formación continua, sin permanencia.</td><td>desde 390 €/mes</td></tr>
+          <tr><td><a href={url('/servicios/diagnostico-ia/')}>Diagnóstico de IA</a></td><td>En 2 semanas: el mapa de tus procesos, las 2-3 automatizaciones con más ahorro y su coste cerrado.</td></tr>
+          <tr><td><a href={url('/servicios/automatizacion/')}>Automatización a medida</a></td><td>Implantación en 2-4 semanas, equipo formado y herramientas a tu nombre.</td></tr>
+          <tr><td><a href={url('/servicios/acompanamiento/')}>Acompañamiento</a></td><td>Mantenimiento, mejoras y formación continua, sin permanencia.</td></tr>
         </tbody>
       </table>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts'
         </div>
         <h3 class="card__title">1. Diagnóstico de IA</h3>
         <p class="card__desc">
-          En dos semanas sabes qué procesos merece la pena automatizar, cuánto cuesta y qué ahorro esperar. Desde 490&nbsp;&euro;, descontable del proyecto.
+          En dos semanas sabes qué procesos merece la pena automatizar, cuánto cuesta y qué ahorro esperar. Con precio cerrado y descontable del proyecto.
         </p>
         <span class="card__link">Saber más</span>
       </a>
@@ -173,7 +173,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts'
         </div>
         <h3 class="card__title">2. Automatización a medida</h3>
         <p class="card__desc">
-          Implanto la automatización en tu negocio en 2-4 semanas: atención al cliente, presupuestos, facturas, informes. Proyecto cerrado desde 1.900&nbsp;&euro;.
+          Implanto la automatización en tu negocio en 2-4 semanas: atención al cliente, presupuestos, facturas, informes. Proyecto cerrado en alcance, plazo y precio.
         </p>
         <span class="card__link">Saber más</span>
       </a>
@@ -187,7 +187,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TAGLINE, CONTACT_EMAIL } from '../consts'
         </div>
         <h3 class="card__title">3. Acompañamiento mensual</h3>
         <p class="card__desc">
-          Mantenimiento, mejoras y formación continua para tu equipo. Tu socio tecnológico desde 390&nbsp;&euro;/mes, sin permanencia.
+          Mantenimiento, mejoras y formación continua para tu equipo. Tu socio tecnológico mes a mes, sin permanencia.
         </p>
         <span class="card__link">Saber más</span>
       </a>

--- a/src/pages/playbook.astro
+++ b/src/pages/playbook.astro
@@ -39,7 +39,7 @@ const faqs = [
   },
   {
     q: '¿Cuánto cuesta poner el primer agente en una pyme en 2026?',
-    a: 'Un diagnóstico de IA para saber qué automatizar primero ronda los 490 € y se descuenta del proyecto. Una automatización a medida bien acotada suele costar entre 1.900 y 4.500 € (precios de 2026). Lo importante no es el precio de la herramienta, sino el alcance cerrado por escrito y el ahorro de horas que mides antes y después.',
+    a: 'Depende del proceso y de cuántos sistemas haya que conectar, pero como orientación: un diagnóstico para saber qué automatizar primero cuesta unos cientos de euros y se descuenta del proyecto, y una automatización a medida bien acotada se mueve en una horquilla de unos pocos miles (precios de 2026). Lo importante no es el precio de la herramienta, sino el alcance cerrado por escrito y el ahorro de horas que mides antes y después.',
   },
   {
     q: '¿Por dónde empiezo si no tengo conocimientos técnicos?',
@@ -338,13 +338,14 @@ const faqSchema = {
         <li>Compáralo con la inversión del proyecto. Eso es tu retorno, y el plazo en que se paga.</li>
       </ol>
       <p>
-        Como referencia de mercado en 2026, una <a href={url('/servicios/diagnostico-ia/')}>diagnóstico de IA</a>
-        para saber qué automatizar primero ronda los <strong>490&nbsp;€</strong> (y se descuenta del proyecto);
-        una <a href={url('/servicios/automatizacion/')}>automatización a medida</a> bien acotada,
-        entre <strong>1.900 y 4.500&nbsp;€</strong>; y el
-        <a href={url('/servicios/acompanamiento/')}>acompañamiento mensual</a> para mantenerla y mejorarla,
-        desde <strong>390&nbsp;€/mes</strong>. Lo que mueve la aguja no es el precio de la herramienta, sino
-        elegir bien el proceso y cerrar el alcance por escrito.
+        Como referencia de mercado en 2026, y solo a modo de orientación, un
+        <a href={url('/servicios/diagnostico-ia/')}>diagnóstico de IA</a> para saber qué automatizar primero
+        suele rondar unos cientos de euros (y se descuenta del proyecto); una
+        <a href={url('/servicios/automatizacion/')}>automatización a medida</a> bien acotada se mueve en una
+        horquilla de unos pocos miles; y el <a href={url('/servicios/acompanamiento/')}>acompañamiento mensual</a>
+        para mantenerla y mejorarla, en una cuota mensual. Lo que mueve la aguja no es el precio de la
+        herramienta, sino elegir bien el proceso y cerrar el alcance por escrito: el importe exacto lo
+        acordamos según tu caso, sin sorpresas.
       </p>
 
       <h2 id="rgpd"><span class="pb-prose__num">08</span>RGPD y tus datos: lo mínimo imprescindible</h2>


### PR DESCRIPTION
Quita los importes en euros de las superficies de venta (home, landings
de asesorías y abogados, páginas de servicio y sectores) y mantiene el
lenguaje cualitativo de marca: "precio cerrado", "sin permanencia",
"IVA aparte". Elimina también los datos estructurados de precio (offers)
de las landings.

Las cifras quedan solo como referencia orientativa donde el lector las
busca expresamente: el apartado de coste del playbook (ya sin negritas)
y la guía de precios del blog, redactada en rangos orientativos.